### PR TITLE
fix import on linux kernel >= 4.11.0

### DIFF
--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -45,7 +45,14 @@
 	#include <linux/semaphore.h>
 #endif
 	#include <linux/sem.h>
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0))
+	#define HAVE_SIGNAL_FUNCTIONS_OWN_HEADER
+#endif
+#ifdef HAVE_SIGNAL_FUNCTIONS_OWN_HEADER
+	#include <linux/sched/signal.h>
+#else
 	#include <linux/sched.h>
+#endif
 	#include <linux/etherdevice.h>
 	#include <linux/wireless.h>
 	#include <net/iw_handler.h>


### PR DESCRIPTION
The sched library now has a new location on linux kernel >= 4.11.0. This commit allows builds to occur on both pre and post 4.11.0 linux kernels.