### PR TITLE
support for WI-U2-433DHP

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -199,6 +199,7 @@ static struct usb_device_id rtw_usb_id_tbl[] ={
 	{USB_DEVICE(0x0411, 0x0242),.driver_info = RTL8821}, /* ELECOM - WDC-433DU2H */
 	{USB_DEVICE(0x2019, 0xAB32),.driver_info = RTL8821}, /* Planex - GW-450S */
 	{USB_DEVICE(0x0846, 0x9052),.driver_info = RTL8821}, /* Netgear - A6100 */
+	{USB_DEVICE(0x0411, 0x029b),.driver_info = RTL8821}, /* Buffalo - WI-U2-433DHP */
 #endif
 
 #ifdef CONFIG_RTL8192E


### PR DESCRIPTION
- support for `WI-U2-433DHP` by buffalo
- monitor mode worked
- a famous USB WiFi adapter in Japan

product web site: http://buffalo.jp/product/wireless-lan/client/wi-u2-433dhp/
