### PR TITLE
Fix for the missing VHT capabilities 

### DIFF
--- a/hal/rtl8812a/rtl8812a_hal_init.c
+++ b/hal/rtl8812a/rtl8812a_hal_init.c
@@ -6351,7 +6351,7 @@ u8 GetHalDefVar8812A(PADAPTER padapter, HAL_DEF_VARIABLE variable, void *pval)
 		break;
 
 	case HAL_DEF_RX_STBC:
-		*(u8 *)pval = 1;
+		*(u8 *)pval = 2;
 		break;
 
 	case HAL_DEF_EXPLICIT_BEAMFORMER:

--- a/hal/rtl8814a/rtl8814a_hal_init.c
+++ b/hal/rtl8814a/rtl8814a_hal_init.c
@@ -6632,7 +6632,7 @@ u8 GetHalDefVar8814A(PADAPTER padapter, HAL_DEF_VARIABLE variable, void *pval)
 			break;
 
 		case HAL_DEF_RX_STBC:
-			*(u8*)pval = 1;
+			*(u8*)pval = 4;
 			break;
 
 		case HAL_DEF_EXPLICIT_BEAMFORMER:

--- a/include/rtw_vht.h
+++ b/include/rtw_vht.h
@@ -139,5 +139,6 @@ void	rtw_process_vht_op_mode_notify(_adapter *padapter, u8 *pframe, PVOID sta);
 u32	rtw_restructure_vht_ie(_adapter *padapter, u8 *in_ie, u8 *out_ie, uint in_len, uint *pout_len);
 void	VHTOnAssocRsp(_adapter *padapter);
 u8	rtw_vht_mcsmap_to_nss(u8 *pvht_mcs_map);
+extern const u16 VHT_MCS_DATA_RATE[3][2][30];
 
 #endif /* _RTW_VHT_H_ */

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -6248,7 +6248,7 @@ static void rtw_cfg80211_init_vht_capab(_adapter *padapter, struct ieee80211_sta
 	/* B8 B9 B10 Rx STBC */
 	if(TEST_FLAG(pvhtpriv->stbc_cap, STBC_VHT_ENABLE_RX)) {
 	  rtw_hal_get_def_var(padapter, HAL_DEF_RX_STBC, (u8 *)(&rx_stbc_nss));
-	  printk("rx_stbc_nss: %d", rx_stbc_nss);
+
 	  if (rx_stbc_nss == 1)
 	    vht_cap->cap |= IEEE80211_VHT_CAP_RXSTBC_1;
 	  else if (rx_stbc_nss == 2)

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -227,7 +227,7 @@ int rtw_antdiv_type = 0
 int rtw_drv_ant_band_switch = 1; /* 0:OFF , 1:ON, Driver control antenna band switch*/
 
 /* 0: doesn't switch, 1: switch from usb2.0 to usb 3.0 2: switch from usb3.0 to usb 2.0 */
-int rtw_switch_usb_mode = 0;
+int rtw_switch_usb_mode = 1;
 
 #ifdef CONFIG_USB_AUTOSUSPEND
 int rtw_enusbss = 1;/* 0:disable,1:enable */


### PR DESCRIPTION
Turns out the old vht capabilities function had a small set of hardcoded capabilities and was not really trying to detect anything. Replaced this function with one similar to the HT function (which actually does some work). Also corrected an error in the hal init which had a hardcoded number of steams of 1. This is wrong, as the 8812 supports 2 streams.

In addition, the default setting for the usb modeswitch was set to enable USB3. No need to explicitly specify the module parameter anymore unless you really really want USB2 only.
