### PR TITLE
RadioTap FCS flag fix

### DIFF
--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -3608,7 +3608,7 @@ static sint fill_radiotap_hdr(_adapter *padapter, union recv_frame *precvframe)
 		hdr_buf[rt_len] |= IEEE80211_RADIOTAP_F_FRAG;
 
 	/* always append FCS */
-	hdr_buf[rt_len] |= IEEE80211_RADIOTAP_F_FCS;
+	/* hdr_buf[rt_len] |= IEEE80211_RADIOTAP_F_FCS; */
 
 	if (0)
 		hdr_buf[rt_len] |= IEEE80211_RADIOTAP_F_DATAPAD;


### PR DESCRIPTION
* The driver marks all frames as containing the Frame Check Sequence at the end. This confuses Wireshark because the FCS field is stripped before the frame is released on the monitor interface.
 v5.1.5

Fix provided by @jcard0na