### PR TITLE
Small fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -568,6 +568,8 @@ endif
 endif
 
 ########### HAL_RTL8814A #################################
+ifeq ($(CONFIG_RTL8814A), y)
+
 RTL871X = rtl8814a
 ifeq ($(CONFIG_USB_HCI), y)
 MODULE_NAME = 8814au
@@ -616,6 +618,8 @@ _HAL_INTFS_FILES +=hal/efuse/$(RTL871X)/HalEfuseMask8814A_USB.o
 endif
 ifeq ($(CONFIG_PCI_HCI), y)
 _HAL_INTFS_FILES +=hal/efuse/$(RTL871X)/HalEfuseMask8814A_PCIE.o
+endif
+
 endif
 
 ########### HAL_RTL8723C #################################

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ CONFIG_AP_WOWLAN = n
 ######### Notify SDIO Host Keep Power During Syspend ##########
 CONFIG_RTW_SDIO_PM_KEEP_POWER = y
 ###################### MP HW TX MODE FOR VHT #######################
-CONFIG_MP_VHT_HW_TX_MODE = n
+CONFIG_MP_VHT_HW_TX_MODE = y
 ###################### Platform Related #######################
 CONFIG_PLATFORM_I386_PC = y
 CONFIG_PLATFORM_ARM_RPI = n
@@ -1038,7 +1038,8 @@ ifeq ($(CONFIG_PLATFORM_I386_PC), y)
 EXTRA_CFLAGS += -mhard-float
 else
 ## For ARM ToolChain use Hardware FLOATING
-EXTRA_CFLAGS += -mfloat-abi=hard
+# Raspbian kernel is with soft-float, so can't do this here
+#EXTRA_CFLAGS += -mfloat-abi=hard
 endif
 endif
 

--- a/os_dep/linux/ioctl_mp.c
+++ b/os_dep/linux/ioctl_mp.c
@@ -14,6 +14,11 @@
  *****************************************************************************/
 #if defined(CONFIG_MP_INCLUDED)
 
+#ifdef CONFIG_MP_VHT_HW_TX_MODE
+	#include <linux/kernel.h>
+	#include <asm/fpu/api.h>
+#endif
+
 #include <drv_types.h>
 #include <rtw_mp.h>
 #include <rtw_mp_ioctl.h>
@@ -826,7 +831,7 @@ int rtw_mp_disable_bt_coexist(struct net_device *dev,
 	u32 bt_coexist;
 
 	_rtw_memset(input, 0, sizeof(input));
-	
+
 	if (copy_from_user(input, wrqu->data.pointer, wrqu->data.length))
 		return -EFAULT;
 
@@ -1617,14 +1622,16 @@ int rtw_mp_tx(struct net_device *dev,
 
 			PMAC_Get_Pkt_Param(&pMptCtx->PMacTxInfo, &pMptCtx->PMacPktInfo);
 
+			kernel_fpu_begin();
 			if (MPT_IS_CCK_RATE(pMptCtx->PMacTxInfo.TX_RATE))
-
-				CCK_generator(&pMptCtx->PMacTxInfo, &pMptCtx->PMacPktInfo);
+				CCK_generator(&pMptCtx->PMacTxInfo, &pMptCtx->PMacPktInfo);	// Floating-Point!
 			else {
-				PMAC_Nsym_generator(&pMptCtx->PMacTxInfo, &pMptCtx->PMacPktInfo);
+				PMAC_Nsym_generator(&pMptCtx->PMacTxInfo, &pMptCtx->PMacPktInfo);	// Floating-Point!
 				/* 24 BIT*/
-				L_SIG_generator(pMptCtx->PMacPktInfo.N_sym, &pMptCtx->PMacTxInfo, &pMptCtx->PMacPktInfo);
+				L_SIG_generator(pMptCtx->PMacPktInfo.N_sym, &pMptCtx->PMacTxInfo, &pMptCtx->PMacPktInfo);	// Floating-Point!
 			}
+			kernel_fpu_end();
+
 			/*	48BIT*/
 			if (MPT_IS_HT_RATE(pMptCtx->PMacTxInfo.TX_RATE))
 				HT_SIG_generator(&pMptCtx->PMacTxInfo, &pMptCtx->PMacPktInfo);
@@ -1640,7 +1647,6 @@ int rtw_mp_tx(struct net_device *dev,
 			}
 
 			mpt_ProSetPMacTx(padapter);
-
 		} else if (strncmp(extra, "pmact,mode=", 11) == 0) {
 			int txmode = 0;
 
@@ -2227,7 +2233,7 @@ int rtw_mp_SetBT(struct net_device *dev,
 		return -EFAULT;
 
 	*(extra + wrqu->data.length) = '\0';
-	
+
 	if (strlen(extra) < 1)
 		return -EFAULT;
 

--- a/os_dep/linux/wifi_regd.c
+++ b/os_dep/linux/wifi_regd.c
@@ -260,6 +260,7 @@ static void _rtw_reg_apply_active_scan_flags(struct wiphy *wiphy,
  */
 static void _rtw_reg_apply_radar_flags(struct wiphy *wiphy)
 {
+#ifndef CONFIG_DISABLE_REGD_C
 	struct ieee80211_supported_band *sband;
 	struct ieee80211_channel *ch;
 	unsigned int i;
@@ -306,6 +307,7 @@ static void _rtw_reg_apply_radar_flags(struct wiphy *wiphy)
 				     IEEE80211_CHAN_PASSIVE_SCAN;
 #endif
 	}
+#endif // CONFIG_DISABLE_REGD_C
 }
 
 static void _rtw_reg_apply_flags(struct wiphy *wiphy)


### PR DESCRIPTION
Contains a  number of small fixes:
- Complete CONFIG_DISABLE_REGD_C to not apply any radar restrictions (tested)
- Restore a lost if/endif pair for CONFIG_RTL8814A
- Mark floating point regions, to not disturb user space
- Don't use hard-float on arm, at least the raspberry-pi kernel is compiled with soft-float