### PR TITLE
Fix floating point in VHT_HW_TX for both x86 and rpi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1040,10 +1040,12 @@ EXTRA_CFLAGS += -DCONFIG_MP_VHT_HW_TX_MODE
 ifeq ($(CONFIG_PLATFORM_I386_PC), y)
 ## For I386 X86 ToolChain use Hardware FLOATING
 EXTRA_CFLAGS += -mhard-float
+EXTRA_CFLAGS += -DMARK_KERNEL_PFU
 else
 ## For ARM ToolChain use Hardware FLOATING
-# Raspbian kernel is with soft-float, so can't do this here
-#EXTRA_CFLAGS += -mfloat-abi=hard
+# Raspbian kernel is with soft-float.
+# 'softfp' allows FP instructions, but no FP on function call interfaces
+EXTRA_CFLAGS += -mfloat-abi=softfp
 endif
 endif
 

--- a/os_dep/linux/ioctl_mp.c
+++ b/os_dep/linux/ioctl_mp.c
@@ -14,7 +14,7 @@
  *****************************************************************************/
 #if defined(CONFIG_MP_INCLUDED)
 
-#ifdef CONFIG_MP_VHT_HW_TX_MODE
+#ifdef MARK_KERNEL_PFU
 	#include <linux/kernel.h>
 	#include <asm/fpu/api.h>
 #endif
@@ -1622,7 +1622,9 @@ int rtw_mp_tx(struct net_device *dev,
 
 			PMAC_Get_Pkt_Param(&pMptCtx->PMacTxInfo, &pMptCtx->PMacPktInfo);
 
-			kernel_fpu_begin();
+			#ifdef MARK_KERNEL_PFU
+				kernel_fpu_begin();
+			#endif
 			if (MPT_IS_CCK_RATE(pMptCtx->PMacTxInfo.TX_RATE))
 				CCK_generator(&pMptCtx->PMacTxInfo, &pMptCtx->PMacPktInfo);	// Floating-Point!
 			else {
@@ -1630,7 +1632,9 @@ int rtw_mp_tx(struct net_device *dev,
 				/* 24 BIT*/
 				L_SIG_generator(pMptCtx->PMacPktInfo.N_sym, &pMptCtx->PMacTxInfo, &pMptCtx->PMacPktInfo);	// Floating-Point!
 			}
-			kernel_fpu_end();
+			#ifdef MARK_KERNEL_PFU
+				kernel_fpu_end();
+			#endif
 
 			/*	48BIT*/
 			if (MPT_IS_HT_RATE(pMptCtx->PMacTxInfo.TX_RATE))


### PR DESCRIPTION
Fix my previous pull request, which doesn't compile on an Rpi3:

This makes CONFIG_MP_VHT_HW_TX_MODE compile on both x86 and rpi.
On x86, floating-point instructions should be guarded, to prevent changing state in user-space.
On rpi, floating-points are not allowed on the interface, but can be emitted inside fuctions using 'softfp'