### PR TITLE
Add -Wno-cast-function-type to EXTRA_CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ EXTRA_CFLAGS += -Wno-unused-label
 EXTRA_CFLAGS += -Wno-unused-parameter
 EXTRA_CFLAGS += -Wno-unused-function
 EXTRA_CFLAGS += -Wno-unused
+EXTRA_CFLAGS += -Wno-cast-function-type
 EXTRA_CFLAGS += -Wno-date-time
 #EXTRA_CFLAGS += -Wno-misleading-indentation
 EXTRA_CFLAGS += -Wno-uninitialized

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Kali](https://img.shields.io/badge/Kali-supported-blue.svg)](https://www.kali.org)
 [![Arch](https://img.shields.io/badge/Arch-supported-blue.svg)](https://www.archlinux.org)
 [![Armbian](https://img.shields.io/badge/Armbian-supported-blue.svg)](https://www.armbian.com)
+[![ArchLinux](https://img.shields.io/badge/ArchLinux-supported-blue.svg)](https://img.shields.io/badge/ArchLinux-supported-blue.svg)
 [![aircrack-ng](https://img.shields.io/badge/aircrack--ng-supported-blue.svg)](https://github.com/aircrack-ng/aircrack-ng)
 [![wifite2](https://img.shields.io/badge/wifite2-supported-blue.svg)](https://github.com/derv82/wifite2)
 


### PR DESCRIPTION
There are legitimate warnings regarding invalid casts of function types.
The core issue are the functions rtl8822bu_xmit_tasklet and
usb_recv_tasklet, which accept 'void *' but immediately cast to
'_adapter *'. Both functions should accept '_adapter *' in the first
place to expose the actual signature.

The error could be fixed in several ways:

    1. using uintptr_t instead of 'void *'
    2. using '_adapter *' and adapting several functions up to,
       including,  linux/interrupt.h
    3. silencing the bug explicitly

Option (1) would only silently hide the bug. Option (2) is unacceptable
because a driver module cannot mess around with a core Linux header.
This leaves us with option (3). By explicitly silencing the problem it
can be easily uncovered later.