### PR TITLE
Fix a check for IPv6 disbling in dkms installer

### DIFF
--- a/dkms-install.sh
+++ b/dkms-install.sh
@@ -20,7 +20,7 @@ RESULT=$?
 
 echo "Finished running dkms install steps."
 
-if defined(CONFIG_DISABLE_IPV6)
+if grep -q -e "^CONFIG_DISABLE_IPV6 = y$" "$DRV_DIR/Makefile" ; then
 	if echo "net.ipv6.conf.all.disable_ipv6 = 1
   net.ipv6.conf.default.disable_ipv6 = 1
   net.ipv6.conf.lo.disable_ipv6 = 1" >> /etc/sysctl.conf; then
@@ -29,6 +29,6 @@ if defined(CONFIG_DISABLE_IPV6)
 	else
 		echo "Could not disable IPv6"
 	fi
-endif
+fi
 
 exit $RESULT

--- a/dkms-install.sh
+++ b/dkms-install.sh
@@ -7,7 +7,7 @@ else
   echo "About to run dkms install steps..."
 fi
 
-DRV_DIR='pwd'
+DRV_DIR="$(pwd)"
 DRV_NAME=rtl8812au
 DRV_VERSION=5.3.4
 


### PR DESCRIPTION
This fixes a bug in DKMS compilation introduced in commit 3fcba157.

@kimocoder you've been so hard at work that I had to bisect to find this one :laughing: 

```
.....
$ git bisect good
3fcba157f907430c19ec01b156446e799b0c73aa is the first bad commit
Author: kimocoder <christian@aircrack-ng.org>
Date:   Sun Apr 7 18:20:30 2019 +0200

    dkms-install: Don't hardcode parent folder          

:100755 100755 b4c437900dea95bd35fa1c385f94a348c0b4c3d9 084ec68880c50d6019c03b1cbd01ba2789b325b1 M      dkms-install.sh
```