### PR TITLE
Fix 3.14 compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
             - gcc-5
             - libelf-dev
             - libssl1.1
-      env: COMPILER=gcc-5 KVER=4.20-rc1
+      env: COMPILER=gcc-5 KVER=5.1-rc4
     - compiler: gcc
       addons:
         apt:
@@ -41,7 +41,7 @@ matrix:
             - gcc-6
             - libelf-dev
             - libssl1.1
-      env: COMPILER=gcc-6 KVER=4.19.1
+      env: COMPILER=gcc-6 KVER=5.1-rc4
     - compiler: gcc
       addons:
         apt:
@@ -52,23 +52,40 @@ matrix:
             - gcc-7
             - libelf-dev
             - libssl1.1
-      env: COMPILER=gcc-7 KVER=4.19.1
+      env: COMPILER=gcc-7 KVER=5.1-rc4
     - compiler: gcc
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
             - gcc-5
-      env: COMPILER=gcc-5 KVER=4.4.97
+            - libelf-dev
+            - libssl1.1
+      env: COMPILER=gcc-5 KVER=4.19.34
     - compiler: gcc
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
-            - gcc-4.9
-      env: COMPILER=gcc-4.9 KVER=3.16.50
+            - gcc-6
+            - libelf-dev
+            - libssl1.1
+      env: COMPILER=gcc-6 KVER=4.19.34
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:ondrej/nginx-mainline'
+          packages:
+            - gcc-7
+            - libelf-dev
+            - libssl1.1
+      env: COMPILER=gcc-7 KVER=4.19.34
     - compiler: gcc
       addons:
         apt:
@@ -77,3 +94,4 @@ matrix:
           packages:
             - gcc-5
       env: COMPILER=gcc-5 KVER=3.14.79
+

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -4662,7 +4662,15 @@ exit:
 	return ret;
 }
 
-static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev, struct station_del_parameters *params)
+static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev,
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
+	u8 *mac
+#elif (LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0))
+	const u8 *mac
+#else
+	struct station_del_parameters *params
+#endif
+)
 {
 	int ret = 0;
 	_irqL irqL;
@@ -4676,7 +4684,11 @@ static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev
 
 	RTW_INFO("+"FUNC_NDEV_FMT"\n", FUNC_NDEV_ARG(ndev));
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0))
+	target_mac = mac;
+#else
 	target_mac = params->mac;
+#endif
 
 	if (check_fwstate(pmlmepriv, (_FW_LINKED | WIFI_AP_STATE | WIFI_MESH_STATE)) != _TRUE) {
 		RTW_INFO("%s, fw_state != FW_LINKED|WIFI_AP_STATE|WIFI_MESH_STATE\n", __func__);

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -1996,7 +1996,8 @@ static int cfg80211_rtw_get_station(struct wiphy *wiphy,
         sinfo->tx_failed = psta->sta_stats.tx_fail_cnt;
 
 	sinfo->filled |= STATION_INFO_BSS_PARAM;
-
+	
+#if defined (LINUX_VERSION_CODE) && (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 20, 0))
 	if (!psta->no_short_preamble_set)
 	sinfo->bss_param.flags |= STATION_INFO_BSS_PARAM_SHORT_PREAMBLE;
 
@@ -2012,7 +2013,7 @@ static int cfg80211_rtw_get_station(struct wiphy *wiphy,
 	sinfo->bss_param.dtim_period = pwrctl->dtim;
 
 	sinfo->bss_param.beacon_interval = get_beacon_interval(&cur_network->network);
-
+#endif
 	}
 
 	/* for Ad-Hoc/AP mode */

--- a/os_dep/linux/ioctl_cfg80211.h
+++ b/os_dep/linux/ioctl_cfg80211.h
@@ -336,7 +336,11 @@ void rtw_cfg80211_deinit_rfkill(struct wiphy *wiphy);
 
 #define rtw_cfg80211_connect_result(wdev, bssid, req_ie, req_ie_len, resp_ie, resp_ie_len, status, gfp) cfg80211_connect_result(wdev_to_ndev(wdev), bssid, req_ie, req_ie_len, resp_ie, resp_ie_len, status, gfp)
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0))
+#define rtw_cfg80211_disconnected(wdev, reason, ie, ie_len, locally_generated, gfp) cfg80211_disconnected(wdev_to_ndev(wdev), reason, ie, ie_len, gfp)
+#else
 #define rtw_cfg80211_disconnected(wdev, reason, ie, ie_len, locally_generated, gfp) cfg80211_disconnected(wdev_to_ndev(wdev), reason, ie, ie_len, locally_generated, gfp)
+#endif
 
 #ifdef CONFIG_RTW_80211R
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0))

--- a/os_dep/linux/rtw_cfgvendor.c
+++ b/os_dep/linux/rtw_cfgvendor.c
@@ -45,9 +45,11 @@ struct sk_buff *dbg_rtw_cfg80211_vendor_event_alloc(struct wiphy *wiphy, struct 
 {
 	struct sk_buff *skb;
 	unsigned int truesize = 0;
-
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 1, 0))
+	skb = cfg80211_vendor_event_alloc(wiphy, len, event_id, gfp);
+#else
 	skb = cfg80211_vendor_event_alloc(wiphy, wdev, len, event_id, gfp);
-
+#endif
 	if (skb)
 		truesize = skb->truesize;
 
@@ -140,9 +142,11 @@ struct sk_buff *rtw_cfg80211_vendor_event_alloc(
 	struct wiphy *wiphy, struct wireless_dev *wdev, int len, int event_id, gfp_t gfp)
 {
 	struct sk_buff *skb;
-
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 1, 0))
+	skb = cfg80211_vendor_event_alloc(wiphy, len, event_id, gfp);
+#else
 	skb = cfg80211_vendor_event_alloc(wiphy, wdev, len, event_id, gfp);
-
+#endif
 	return skb;
 }
 


### PR DESCRIPTION
The AmLogic 3.14 legacy kernel is still used on some ARM devices.
This PR fix the compilation issues and update the Travis CI script to last mainline and LTS kernels.