### PR TITLE
os_dep: fix compilation warning and kernel 5.2

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -9458,9 +9458,6 @@ static struct cfg80211_ops rtw_cfg80211_ops = {
 	.set_pmksa = cfg80211_rtw_set_pmksa,
 	.del_pmksa = cfg80211_rtw_del_pmksa,
 	.flush_pmksa = cfg80211_rtw_flush_pmksa,
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,11,0))
-	.set_monitor_channel = cfg80211_rtw_set_monitor_channel,
-#endif
 
 #ifdef CONFIG_AP_MODE
 	.add_virtual_intf = cfg80211_rtw_add_virtual_intf,

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1273,20 +1273,18 @@ unsigned int rtw_classify8021d(struct sk_buff *skb)
 	return dscp >> 5;
 }
 
-#if (LINUX_VERSION_CODE>=KERNEL_VERSION(4,19,0))
-static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb,
-				struct net_device *sb_dev,
-				select_queue_fallback_t fallback)
-#else
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
+	#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,19,0))
 	, void *accel_priv
-	#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
+	#else
+	, struct net_device *sb_dev
+	#endif
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(5, 2, 0))
 	, select_queue_fallback_t fallback
 	#endif
 #endif
 )
-#endif
 {
 	_adapter	*padapter = rtw_netdev_priv(dev);
 	struct mlme_priv *pmlmepriv = &padapter->mlmepriv;


### PR DESCRIPTION
This fixes a override-init warning and allows compilation with the 5.2 kernel.