### PR TITLE
linux-5.2: disable fallback from rtw_select_queue

### DIFF
--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1255,7 +1255,7 @@ static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
   #else
     , struct net_device *sb_dev
   #endif
-  #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
+  #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(5, 2, 0))
 	  , select_queue_fallback_t fallback
   #endif
 #endif


### PR DESCRIPTION
The fallback parameter has been removed in the latest kernel (>= 5.2)

See: https://github.com/torvalds/linux/commit/a350eccee5830d9a1f29e393a88dc05a15326d44