### PR TITLE
Add support for TP-Link Archer T2U v3

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -222,6 +222,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE(0x2357, 0x011E), .driver_info = RTL8821}, /* TP Link - T2U Nano */
 	{USB_DEVICE(0x2357, 0x0122), .driver_info = RTL8821}, /* TP Link - T2U Nano */
 	{USB_DEVICE(0x2357, 0x0120), .driver_info = RTL8821}, /* TP Link - T2U Plus */
+	{USB_DEVICE(0x2357, 0x011F), .driver_info = RTL8821}, /* TP Link - T2U v3 */
 #endif
 
 #ifdef CONFIG_RTL8192E


### PR DESCRIPTION
Bus 001 Device 002: ID 2357:011f TP-Link 802.11ac WLAN Adapter 
