### PR TITLE
Fix compilation issue kernels < 4.18 (Ubuntu 18.04 and derived distros)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,3 +74,13 @@ matrix:
             - gcc-7
             - libssl1.1
       env: COMPILER=gcc-7 KVER=4.19.67
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:ondrej/nginx-mainline'
+          packages:
+            - gcc-7
+            - libssl1.1
+      env: COMPILER=gcc-7 KVER=4.15.18

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -4481,7 +4481,9 @@ void rtw_cfg80211_indicate_sta_assoc(_adapter *padapter, u8 *pmgmt_frame, uint f
 		sinfo.filled = STATION_INFO_ASSOC_REQ_IES;
 		sinfo.assoc_req_ies = pmgmt_frame + WLAN_HDR_A3_LEN + ie_offset;
 		sinfo.assoc_req_ies_len = frame_len - WLAN_HDR_A3_LEN - ie_offset;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 18, 0))
 		cfg80211_sinfo_alloc_tid_stats(&sinfo, GFP_KERNEL);
+#endif
 		cfg80211_new_sta(ndev, get_addr2_ptr(pmgmt_frame), &sinfo, GFP_ATOMIC);
 	}
 #else /* defined(RTW_USE_CFG80211_STA_EVENT) */


### PR DESCRIPTION
As requested on #419 

Linux Mint 19 use a EOL kernel (like Ubuntu18.04)
I have made a new Travis build using similar kernel and gcc compiler.
 The fix for the issue just remove the function cfg80211_sinfo_alloc_tid_stats, introduced at https://github.com/torvalds/linux/commit/8689c051a20195b228e19acb155c7d6e48a86753#diff-35454f3f0395271a0e34581e160bea5f


Fix  #419 
Fix  #436