### PR TITLE
Fix oops on interface rename

### DIFF
--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1404,7 +1404,7 @@ static u8 is_rtw_ndev(struct net_device *ndev)
 static int rtw_ndev_notifier_call(struct notifier_block *nb, unsigned long state, void *ptr)
 {
 	struct net_device *ndev;
-	_adapter *adapter = rtw_netdev_priv(ndev);
+	_adapter *adapter;
 
 	if (ptr == NULL)
 		return NOTIFY_DONE;
@@ -1422,6 +1422,8 @@ static int rtw_ndev_notifier_call(struct notifier_block *nb, unsigned long state
 		return NOTIFY_DONE;
 
 	RTW_INFO(FUNC_NDEV_FMT" state:%lu\n", FUNC_NDEV_ARG(ndev), state);
+
+	adapter = rtw_netdev_priv(ndev);
 
 	switch (state) {
 	case NETDEV_CHANGENAME:


### PR DESCRIPTION
Interface renaming crashes because rtw_ndev_notifier_call() tries to get the adapter from ndev before ndev itself is assigned:

```
[29504.542194] rtl88xxau 3-5:1.0 wlp0s20u5: renamed from wlan0
[29504.561961] BUG: kernel NULL pointer dereference, address: 00000000000008c0
[29504.561966] #PF: supervisor read access in kernel mode
[29504.561968] #PF: error_code(0x0000) - not-present page
[29504.561970] PGD 0 P4D 0
[29504.561974] Oops: 0000 [#1] PREEMPT SMP NOPTI
[29504.561978] CPU: 5 PID: 27127 Comm: systemd-udevd Tainted: G           OE     5.3.1-arch1-1-ARCH #1
[29504.561979] Hardware name:  /DH87RL, BIOS RLH8710H.86A.0331.2018.0327.1547 03/27/2018
[29504.562035] RIP: 0010:rtw_ndev_notifier_call+0x31/0x55 [88XXau]
[29504.562038] Code: d2 74 45 55 53 48 89 f3 48 8b 2a 48 85 ed 74 12 48 89 ef e8 99 fe ff ff 48 83 fb 0b 75 04 84 c0 75 08 b8 00 00 00 00 5b 5d c3 <48> 8b 04 25 c0 08 00 00 48 8d b8 48 45 00 00 ba 10 00 00 00 48 89
[29504.562041] RSP: 0018:ffffb6e28252f7b0 EFLAGS: 00010202
[29504.562043] RAX: 0000000000000001 RBX: 000000000000000b RCX: 0000000000000001
[29504.562045] RDX: ffffffffc149ce80 RSI: 000000000000000b RDI: ffffa35bb1fad000
[29504.562046] RBP: ffffa35bb1fad000 R08: 0000000000800000 R09: ffffffffa489c660
[29504.562047] R10: ffffb6e28252f7c8 R11: ffffb6e38252f6b6 R12: 000000000000000b
[29504.562048] R13: ffffb6e28252f818 R14: ffffffffa4907d20 R15: 0000000000000000
[29504.562050] FS:  00007f638323f840(0000) GS:ffffa35c8eb40000(0000) knlGS:0000000000000000
[29504.562051] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[29504.562053] CR2: 00000000000008c0 CR3: 000000040bcb6006 CR4: 00000000001606e0
[29504.562054] Call Trace:
[29504.562062]  notifier_call_chain+0x4c/0x70
[29504.562067]  dev_change_name+0x219/0x320
[29504.562071]  do_setlink+0xd45/0xf10
[29504.562077]  ? preempt_count_add+0x68/0xa0
[29504.562081]  ? _raw_spin_lock+0x13/0x30
[29504.562083]  ? _raw_spin_unlock+0x16/0x30
[29504.562087]  ? get_partial_node.isra.0.part.0+0xc2/0x210
[29504.562090]  ? __alloc_pages_nodemask+0x1c4/0x10b0
[29504.562093]  rtnl_setlink+0x105/0x170
[29504.562099]  rtnetlink_rcv_msg+0x137/0x3c0
[29504.562101]  ? rtnl_calcit.isra.0+0x120/0x120
[29504.562105]  netlink_rcv_skb+0x75/0x140
[29504.562108]  netlink_unicast+0x177/0x1f0
[29504.562111]  netlink_sendmsg+0x204/0x3d0
[29504.562116]  sock_sendmsg+0x5e/0x60
[29504.562118]  __sys_sendto+0x120/0x190
[29504.562122]  __x64_sys_sendto+0x25/0x30
[29504.562125]  do_syscall_64+0x5f/0x1c0
[29504.562128]  entry_SYSCALL_64_after_hwframe+0x44/0xa9

```
Move the assignment further down after ndev is known.