### PR TITLE
Fix Arm64 compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -604,7 +604,9 @@ else ifeq ($(CONFIG_PLATFORM_ARM_RPI), y)
 EXTRA_CFLAGS += -mfloat-abi=softfp
 else
 ## For ARM ToolChain use Hardware FLOATING
-EXTRA_CFLAGS += -mfloat-abi=hard
+# Raspbian kernel is with soft-float.
+# 'softfp' allows FP instructions, but no FP on function call interfaces
+EXTRA_CFLAGS += -mfloat-abi=softfp
 endif
 endif
 


### PR DESCRIPTION
Close #425 

Solution was described on #173

I don't know the implications of disable `CONFIG_MP_VHT_HW_TX_MODE` so use at you onw risk.

Please check the comments at #233, maybe  #198 should be ported