### PR TITLE
Fix additional character at VENDOR_CWD_RAW_DATA (v.5.2.20)

### DIFF
--- a/os_dep/linux/rtw_cfgvendor.c
+++ b/os_dep/linux/rtw_cfgvendor.c
@@ -1444,7 +1444,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 		.doit = rtw_cfgvendor_rtt_get_capability
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 3, 0))
 		,
-		.policy = VENDOR_CMD_RAW_DATA, æ
+		.policy = VENDOR_CMD_RAW_DATA,
 		.maxattr = 1
 #endif
 		},


### PR DESCRIPTION
Port of #433
Maybe a type error found by @hexc0de 
Note that is a quick fix done at github web interface, please review before merge

