### PR TITLE
Fix some 8814au slow speed issue

### DIFF
--- a/hal/rtl8814a/usb/rtl8814au_xmit.c
+++ b/hal/rtl8814a/usb/rtl8814au_xmit.c
@@ -126,13 +126,13 @@ static s32 update_txdesc(struct xmit_frame *pxmitframe, u8 *pmem, s32 sz ,u8 bag
 
 
 
-		if ((pxmitframe->frame_tag&0x0f) == DATA_FRAMETAG) {
+	if ((pxmitframe->frame_tag&0x0f) == DATA_FRAMETAG) {
 		//RTW_INFO("pxmitframe->frame_tag == DATA_FRAMETAG\n");
 
 		rtl8814a_fill_txdesc_sectype(pattrib, ptxdesc);
 
 		//offset 20
-		}
+
 #ifdef CONFIG_USB_TX_AGGREGATION
 		if (pxmitframe->agg_num > 1){
 			//RTW_INFO("%s agg_num:%d\n",__FUNCTION__,pxmitframe->agg_num );
@@ -223,8 +223,8 @@ static s32 update_txdesc(struct xmit_frame *pxmitframe, u8 *pmem, s32 sz ,u8 bag
 
 			SET_TX_DESC_TX_RATE_8814A(ptxdesc, MRateToHwRate(pmlmeext->tx_rate));
 		}
-
-		if ((pxmitframe->frame_tag&0x0f)== MGNT_FRAMETAG) {
+	}
+	else if ((pxmitframe->frame_tag&0x0f)== MGNT_FRAMETAG) {
 		//RTW_INFO("pxmitframe->frame_tag == MGNT_FRAMETAG\n");
 
 		SET_TX_DESC_USE_RATE_8814A(ptxdesc, 1);


### PR DESCRIPTION
The indent and `if` logic is incorrect in `hal/rtl8814a/usb/rtl8814au_xmit.c` which will make some data frames transmit in lowest rate.