### PR TITLE
Ignore  *.c.orig files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ modules.order
 .cache.mk
 *.mod
 *.o.d
+*.c.orig 


### PR DESCRIPTION
Just to avoid mistakes during diff & merges.
