### PR TITLE
Fix compilation for kernels < 4.10

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -4761,9 +4761,11 @@ static int rtw_cfg80211_add_monitor_if(_adapter *padapter, char *name, struct ne
 		goto out;
 	}
 
-	mon_ndev->min_mtu = WLAN_MIN_ETHFRM_LEN;
 	mon_ndev->mtu = WLAN_DATA_MAXLEN;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0))
+	mon_ndev->min_mtu = WLAN_MIN_ETHFRM_LEN;
 	mon_ndev->max_mtu = WLAN_DATA_MAXLEN;
+#endif
 
 	mon_ndev->type = ARPHRD_IEEE80211_RADIOTAP;
 	strncpy(mon_ndev->name, name, IFNAMSIZ);

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1591,9 +1591,11 @@ struct net_device *rtw_init_netdev(_adapter *old_padapter)
 	if (!pnetdev)
 		return NULL;
 
-	pnetdev->min_mtu = WLAN_MIN_ETHFRM_LEN;
 	pnetdev->mtu = WLAN_DATA_MAXLEN;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0))
+	pnetdev->min_mtu = WLAN_MIN_ETHFRM_LEN;
 	pnetdev->max_mtu = WLAN_DATA_MAXLEN;
+#endif
 
 	pnetdev->dev.type = &wlan_type;
 	padapter = rtw_netdev_priv(pnetdev);

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -2389,9 +2389,11 @@ struct net_device *rtw_alloc_etherdev_with_old_priv(int sizeof_priv, void *old_p
 		goto RETURN;
 
 
-	pnetdev->min_mtu = WLAN_MIN_ETHFRM_LEN;
 	pnetdev->mtu = WLAN_MAX_ETHFRM_LEN;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0))
+	pnetdev->min_mtu = WLAN_MIN_ETHFRM_LEN;
 	pnetdev->max_mtu = WLAN_DATA_MAXLEN;
+#endif
 
 	pnpi = netdev_priv(pnetdev);
 	pnpi->priv = old_priv;
@@ -2414,9 +2416,11 @@ struct net_device *rtw_alloc_etherdev(int sizeof_priv)
 	if (!pnetdev)
 		goto RETURN;
 
-	pnetdev->min_mtu = WLAN_MIN_ETHFRM_LEN;
 	pnetdev->mtu = WLAN_MAX_ETHFRM_LEN;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0))
+	pnetdev->min_mtu = WLAN_MIN_ETHFRM_LEN;
 	pnetdev->max_mtu = WLAN_DATA_MAXLEN;
+#endif
 
 	pnpi = netdev_priv(pnetdev);
 


### PR DESCRIPTION
min_mtu and max_mtu in struct net_device were added in kernel 4.10-rc1:
torvalds/linux@61e8462#diff-cf45716f2ff8e67a1727be77c3b894fe

So it didn't compile on my earlier kernel. Simple patch.