### PR TITLE
Reintroduce: Added LED control

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,31 +186,24 @@ $ sudo iw wlan0 set txpower fixed 3000
 
 ### LED control
 
-#### You can now control LED behaviour statically by Makefile, for example:
-
-```sh
-CONFIG_LED_ENABLE = n
-```
-value can be y or n
-
 #### statically by module parameter in /etc/modprobe.d/8812au.conf or wherever, for example:
 
 ```sh
-options 88XXau rtw_led_enable=0
+options 88XXau rtw_led_ctrl=0
 ```
 value can be 0 or 1
 
-#### or dynamically by writing to /proc/net/rtl8812au/$(your interface name)/led_enable, for example:
+#### or dynamically by writing to /proc/net/rtl8812au/$(your interface name)/led_ctrl, for example:
 
 ```sh
-$ echo "0" > /proc/net/rtl8812au/$(your interface name)/led_enable
+$ echo "0" > /proc/net/rtl8812au/$(your interface name)/led_ctrl
 ```
 value can be 0 or 1
 
 #### check current value:
 
 ```sh
-$ cat /proc/net/rtl8812au/$(your interface name)/led_enable
+$ cat /proc/net/rtl8812au/$(your interface name)/led_ctrl
 ```
 
 ### USB Mode Switch

--- a/core/rtw_debug.c
+++ b/core/rtw_debug.c
@@ -7030,3 +7030,67 @@ inline void RTW_BUF_DUMP_SEL(uint _loglevel, void *sel, u8 *_titlestring,
 }
 
 #endif
+
+#ifdef CONFIG_RTW_SW_LED
+int proc_get_led_ctrl(struct seq_file *m, void *v)
+{
+	struct net_device *dev = m->private;
+	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
+	struct registry_priv	*pregpriv = &padapter->registrypriv;
+
+	if (pregpriv)
+		RTW_PRINT_SEL(m, "%d\n", pregpriv->led_ctrl);
+
+	return 0;
+}
+
+ssize_t proc_set_led_ctrl(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+{
+	struct net_device *dev = data;
+	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
+	struct registry_priv	*pregpriv = &padapter->registrypriv;
+	struct led_priv *ledpriv = adapter_to_led(padapter);
+	char tmp[32];
+	u32 mode;
+
+	if (buffer == NULL || pregpriv == NULL) {
+		RTW_INFO("input buffer is NULL!\n");
+		return -EFAULT;
+	}
+
+	if (count < 1)
+		return -EFAULT;
+
+	if (count > sizeof(tmp)) {
+		rtw_warn_on(1);
+		return -EFAULT;
+	}
+
+	if (buffer && !copy_from_user(tmp, buffer, count)) {
+
+		int num = sscanf(tmp, "%d ", &mode);
+
+		if (num != 1) {
+			RTW_INFO("Invalid format\n");
+			return count;
+		}
+
+		if (mode < 0 || mode > 2 || pregpriv->led_ctrl == mode) {
+			RTW_INFO("Invalid mode\n");
+			return count;
+		}
+
+		if (mode > 0) {
+			pregpriv->led_ctrl = (u8) mode;
+			LedControlUSB(padapter, LED_CTL_POWER_ON);
+		} else {
+			LedControlUSB(padapter, LED_CTL_POWER_OFF);
+			pregpriv->led_ctrl = (u8) mode;
+		}
+
+		RTW_INFO("led_ctrl=%d\n", pregpriv->led_ctrl);
+	}
+
+	return count;
+}
+#endif /* CONFIG_RTW_SW_LED */

--- a/hal/led/hal_usb_led.c
+++ b/hal/led/hal_usb_led.c
@@ -1745,6 +1745,22 @@ void BlinkHandler(PLED_USB pLed)
 		return;
 	}
 
+	#ifdef CONFIG_SW_LED
+	// led_enable 1 is normal blinking so don't cause always on/off
+	if (padapter->registrypriv.led_ctrl != 1) {
+		if (padapter->registrypriv.led_ctrl == 0)
+		{
+			// Cause LED to be always off
+			pLed->BlinkingLedState = RTW_LED_OFF;
+		} else {
+			// Cause LED to be always on for led_ctrl 2 or greater
+			pLed->BlinkingLedState = RTW_LED_ON;
+		}
+		// Skip various switch cases where SwLedBlink*() called below
+		pLed->CurrLedState = LED_UNKNOWN;
+	}
+	#endif
+
 	switch (ledpriv->LedStrategy) {
 	#if CONFIG_RTW_SW_LED_TRX_DA_CLASSIFY
 	case SW_LED_MODE_UC_TRX_ONLY:

--- a/hal/led/hal_usb_led.c
+++ b/hal/led/hal_usb_led.c
@@ -1745,22 +1745,6 @@ void BlinkHandler(PLED_USB pLed)
 		return;
 	}
 
-	#ifdef CONFIG_SW_LED
-	// led_enable 1 is normal blinking so don't cause always on/off
-	if (padapter->registrypriv.led_ctrl != 1) {
-		if (padapter->registrypriv.led_ctrl == 0)
-		{
-			// Cause LED to be always off
-			pLed->BlinkingLedState = RTW_LED_OFF;
-		} else {
-			// Cause LED to be always on for led_ctrl 2 or greater
-			pLed->BlinkingLedState = RTW_LED_ON;
-		}
-		// Skip various switch cases where SwLedBlink*() called below
-		pLed->CurrLedState = LED_UNKNOWN;
-	}
-	#endif
-
 	switch (ledpriv->LedStrategy) {
 	#if CONFIG_RTW_SW_LED_TRX_DA_CLASSIFY
 	case SW_LED_MODE_UC_TRX_ONLY:
@@ -4155,7 +4139,8 @@ LedControlUSB(
 		return;
 	}
 
-	if (ledpriv->bRegUseLed == _FALSE)
+	if (ledpriv->bRegUseLed == _FALSE ||
+	    padapter->registrypriv.led_ctrl == 0)
 		return;
 
 	/* if(priv->bInHctTest) */

--- a/include/drv_types.h
+++ b/include/drv_types.h
@@ -211,6 +211,9 @@ struct registry_priv {
 #ifdef CONFIG_TX_EARLY_MODE
 	u8   early_mode;
 #endif
+#ifdef CONFIG_SW_LED
+	u8   led_ctrl;
+#endif
 	u8	acm_method;
 	/* WMM */
 	u8	wmm_enable;

--- a/include/drv_types.h
+++ b/include/drv_types.h
@@ -211,7 +211,7 @@ struct registry_priv {
 #ifdef CONFIG_TX_EARLY_MODE
 	u8   early_mode;
 #endif
-#ifdef CONFIG_SW_LED
+#ifdef CONFIG_RTW_SW_LED
 	u8   led_ctrl;
 #endif
 	u8	acm_method;

--- a/include/rtw_debug.h
+++ b/include/rtw_debug.h
@@ -563,6 +563,11 @@ ssize_t proc_set_mcc_sta_bw80_target_tp(struct file *file, const char __user *bu
 int proc_get_mcc_policy_table(struct seq_file *m, void *v);
 #endif /* CONFIG_MCC_MODE */
 
+#ifdef CONFIG_RTW_SW_LED
+int proc_get_led_ctrl(struct seq_file *m, void *v);
+ssize_t proc_set_led_ctrl(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data);
+#endif /* CONFIG_RTW_SW_LED */
+
 int proc_get_ack_timeout(struct seq_file *m, void *v);
 ssize_t proc_set_ack_timeout(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data);
 

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -105,6 +105,10 @@ int rtw_check_fw_ps = 1;
 int rtw_early_mode = 1;
 #endif
 
+#ifdef CONFIG_SW_LED
+int rtw_led_ctrl = 1; // default to normal blink
+#endif
+
 int rtw_usb_rxagg_mode = 2;/* RX_AGG_DMA=1, RX_AGG_USB=2 */
 module_param(rtw_usb_rxagg_mode, int, 0644);
 
@@ -460,6 +464,12 @@ module_param(rtw_pci_aspm_enable, int, 0644);
 #ifdef CONFIG_TX_EARLY_MODE
 module_param(rtw_early_mode, int, 0644);
 #endif
+
+#ifdef CONFIG_SW_LED
+module_param(rtw_led_ctrl, int, 0644);
+MODULE_PARM_DESC(rtw_led_ctrl,"Led Control: 0=Always off, 1=Normal blink, 2=Always on");
+#endif
+
 #ifdef CONFIG_ADAPTOR_INFO_CACHING_FILE
 char *rtw_adaptor_info_caching_file_path = "/data/misc/wifi/rtw_cache";
 module_param(rtw_adaptor_info_caching_file_path, charp, 0644);
@@ -1004,6 +1014,9 @@ uint loadparam(_adapter *padapter)
 
 #ifdef CONFIG_TX_EARLY_MODE
 	registry_par->early_mode = (u8)rtw_early_mode;
+#endif
+#ifdef CONFIG_SW_LED
+	registry_par->led_ctrl = (u8)rtw_led_ctrl;
 #endif
 	registry_par->lowrate_two_xmit = (u8)rtw_lowrate_two_xmit;
 	registry_par->rf_config = (u8)rtw_rf_config;

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -105,7 +105,7 @@ int rtw_check_fw_ps = 1;
 int rtw_early_mode = 1;
 #endif
 
-#ifdef CONFIG_SW_LED
+#ifdef CONFIG_RTW_SW_LED
 int rtw_led_ctrl = 1; // default to normal blink
 #endif
 
@@ -465,7 +465,7 @@ module_param(rtw_pci_aspm_enable, int, 0644);
 module_param(rtw_early_mode, int, 0644);
 #endif
 
-#ifdef CONFIG_SW_LED
+#ifdef CONFIG_RTW_SW_LED
 module_param(rtw_led_ctrl, int, 0644);
 MODULE_PARM_DESC(rtw_led_ctrl,"Led Control: 0=Always off, 1=Normal blink, 2=Always on");
 #endif
@@ -1015,7 +1015,7 @@ uint loadparam(_adapter *padapter)
 #ifdef CONFIG_TX_EARLY_MODE
 	registry_par->early_mode = (u8)rtw_early_mode;
 #endif
-#ifdef CONFIG_SW_LED
+#ifdef CONFIG_RTW_SW_LED
 	registry_par->led_ctrl = (u8)rtw_led_ctrl;
 #endif
 	registry_par->lowrate_two_xmit = (u8)rtw_lowrate_two_xmit;

--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -4120,6 +4120,10 @@ const struct rtw_proc_hdl adapter_proc_hdls[] = {
 #endif
 
 	RTW_PROC_HDL_SSEQ("cur_beacon_keys", proc_get_cur_beacon_keys, NULL),
+
+#ifdef CONFIG_RTW_SW_LED
+	RTW_PROC_HDL_SSEQ("led_ctrl", proc_get_led_ctrl, proc_set_led_ctrl),
+#endif
 };
 
 const int adapter_proc_hdls_num = sizeof(adapter_proc_hdls) / sizeof(struct rtw_proc_hdl);


### PR DESCRIPTION
This commit is cherry-pick + refactoring of: gordboy/rtl8812au@ff04a94 and 313311c

I'm not sure how this got lost in the latest revision on GitHub (I guess merging issues).
But all credits go to @gordboy, @kimocoder and all the other authors.

The additional changes are:
- Refactoring of the enable/disable logic
- Fixed conditional definition names
- Update of the documentation

I did tests with two different USB WiFi adapters: [TP-Link Archer T2U Nano](https://www.tp-link.com/us/home-networking/usb-adapter/archer-t2u-nano/) (RTL8821AU) and [ALFA Network AWUS1900](https://www.alfa.com.tw/products_detail/2.htm) (RTL8814AU).