### PR TITLE
Partial fix of Travis build on kernel >=5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 compiler: gcc
 sudo: required
-dist: xenial
+dist: bionic
 
 before_install:
   - export ALL_DEB=$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep -m1 all | cut -d '"' -f 2)
@@ -22,48 +22,38 @@ matrix:
       addons:
         apt:
           sources:
-            - sourceline: 'ppa:ondrej/nginx-mainline'
+            - ubuntu-toolchain-r-test
           packages:
-            - libssl1.1
-      env: COMPILER=gcc-5 KVER=5.4.4
+            - gcc-8
+      env: COMPILER=gcc-8 KVER=5.4.4
+    - compiler: gcc
+      env: COMPILER=gcc-7 KVER=5.4.4
     - compiler: gcc
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
             - gcc-6
-            - libssl1.1
       env: COMPILER=gcc-6 KVER=5.4.4
     - compiler: gcc
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
-            - gcc-7
-            - libssl1.1
-      env: COMPILER=gcc-7 KVER=5.4.4
+            - gcc-8
+      env: COMPILER=gcc-8 KVER=4.19.86
     - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - sourceline: 'ppa:ondrej/nginx-mainline'
-          packages:
-            - libssl1.1
-      env: COMPILER=gcc-5 KVER=4.19.67
+      env: COMPILER=gcc-7 KVER=4.19.86
     - compiler: gcc
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
             - gcc-6
-            - libssl1.1
-      env: COMPILER=gcc-6 KVER=4.19.67
+      env: COMPILER=gcc-6 KVER=4.19.86
     - compiler: gcc
       addons:
         apt:
@@ -72,15 +62,4 @@ matrix:
             - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
             - gcc-7
-            - libssl1.1
-      env: COMPILER=gcc-7 KVER=4.19.67
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:ondrej/nginx-mainline'
-          packages:
-            - gcc-7
-            - libssl1.1
       env: COMPILER=gcc-7 KVER=4.15.18


### PR DESCRIPTION
- Update Travis to bionic
- Add GCC 8 to compilation matrix
- Drop GCC 5 from compilation matrix

Build fails on older GCC versions due this commit
https://github.com/torvalds/linux/commit/eb111869301e15b737315a46c913ae82bd19eb9d

Must work on GCC 7.5, so maybe the better option is just wait until Ubuntu 18 release the [package](https://packages.ubuntu.com/bionic/gcc-7). 

I have tested some changes on a similar driver in order to compile with GCC 6, without lucky.

https://github.com/CGarces/rtl8192eu-linux-driver/commit/1f618970425b1a19ed6be249ff3aa585fee1b104

Ping me if you prefer to remove GCC 6 from the matrix on this PR.