### PR TITLE
Fix travis build GCC 8 and 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 compiler: gcc
 sudo: required
-dist: disco
+dist: bionic
 
 before_install:
   - export ALL_DEB=$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep -m1 all | cut -d '"' -f 2)
@@ -22,19 +22,21 @@ matrix:
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - gcc-9
       env: COMPILER=gcc-9 KVER=5.4.8
     - compiler: gcc
+      addons:
+        apt:
+          packages:
+            - gcc-8
       env: COMPILER=gcc-8 KVER=5.4.8
     - compiler: gcc
       env: COMPILER=gcc-7 KVER=5.4.8
     - compiler: gcc
       addons:
         apt:
-          sources:
-            - ubuntu-toolchain-r-test
           packages:
             - gcc-6
       env: COMPILER=gcc-6 KVER=5.4.8
@@ -42,28 +44,23 @@ matrix:
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - gcc-9
-      env: COMPILER=gcc-9 KVER=4.19.86
-    - compiler: gcc
-      env: COMPILER=gcc-8 KVER=4.19.86
-    - compiler: gcc
-      env: COMPILER=gcc-7 KVER=4.19.86
+      env: COMPILER=gcc-9 KVER=4.19.93
     - compiler: gcc
       addons:
         apt:
-          sources:
-            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-8
+      env: COMPILER=gcc-8 KVER=4.19.93
+    - compiler: gcc
+      env: COMPILER=gcc-7 KVER=4.19.93
+    - compiler: gcc
+      addons:
+        apt:
           packages:
             - gcc-6
-      env: COMPILER=gcc-6 KVER=4.19.86
+      env: COMPILER=gcc-6 KVER=4.19.93
     - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:ondrej/nginx-mainline'
-          packages:
-            - gcc-7
       env: COMPILER=gcc-7 KVER=4.15.18


### PR DESCRIPTION
- Fix error installing GCC-9 due https://github.com/travis-ci/apt-source-safelist/issues/410
- Fix GCC-8 builds
- Update LTS kernel 4.19

GCC 7 build fails but is fixed on 7.5 so will work fine on the future. Maybe should be disabled temporary
GCC 6 is no longer supported, last version is from October 2018. Should be removed.