### PR TITLE
Enable channels 36-48 for AP usage

### DIFF
--- a/os_dep/linux/wifi_regd.c
+++ b/os_dep/linux/wifi_regd.c
@@ -269,7 +269,7 @@ void rtw_regd_apply_flags(struct wiphy *wiphy)
 	u16 channel;
 	//u32 freq;
 
-	/* all channels disable */
+	/* all channels enable */
 	for (i = 0; i < NUM_NL80211_BANDS; i++) {
 		sband = wiphy->bands[i];
 
@@ -280,7 +280,7 @@ void rtw_regd_apply_flags(struct wiphy *wiphy)
 				if (ch)
 					ch->flags &= ~(IEEE80211_CHAN_DISABLED|IEEE80211_CHAN_NO_HT40PLUS|
 						IEEE80211_CHAN_NO_HT40MINUS|IEEE80211_CHAN_NO_80MHZ|
-						IEEE80211_CHAN_NO_160MHZ);
+						IEEE80211_CHAN_NO_160MHZ|IEEE80211_CHAN_NO_IR);
 			}
 		}
 	}


### PR DESCRIPTION
This is quick fix for the problem described in issue https://github.com/aircrack-ng/rtl8812au/issues/473.

In order to fix the code properly though, I believe we would need to debug why all the channels in 5G band are set as PASSIVE/NO_IR by the driver,as this makes all the channels in the 5G band unusable for the purpose of creating AP.

Another problem is that we most likely do not want to remove DFS limitation on the 5G channels (ie. by setting ` ch->flags = 0`), as this violates the regulations and is against the community [2]. What is more - there are extra safeguards in the kernel that will not allow users to launch an AP on the DFS band even if the driver thinks it is OK. Having the driver return a clear error message is better IMO than having the kernel quietly override the channel on which our AP operates.

I am using Raspi4 running arm64 Ubuntu19. I tried to understand why the driver thinks it should mark all the channels as passive in 5Ghz band.  There are flags in the code that seem to be set by some external build scripts which do not exist (e.g. `CONFIG_DFS_SLAVE_WITH_RADAR_DETECT`), lots of information is hard coded and hard to read (no documentation whatsoever) and/or requires deep knowledge about the wifi standards and regulations. The reference implementation for Linux kernel is IMO Atheros drivers and they do not have any problems whatsoever with running AP on 5Ghz band so my GUESS is that this is just a problem with buggy regulations code or some missing build scripts code, not with some wifi regulatory restrictions themselves.

I guess, that it would take a much more time to properly fix it so I decided that the lesser evil option would be to unblock the channels, while keeping the regulatory power limits intact along with DFS restrictions. Hence, even if we miss something, the damage will be limited. The driver itself should support enabling DFS since at least version 5.2.20 [3], but I was unable to make it work[7]. This approach leaves us with only the channels 36-48 available for setting up an AP.

Also, there are not many alternatives as of now really. All the usb3-based 5Ghz band wifi dongles on Amazon right now use either Realtek or Ralink chipsets. DFS works **almost** out-of-the-box[6] only for Atheros chips[5] and I have not seen any decent 5Ghz Atheros based usb3 dongles. What is more - DFS in Atheros chips is still considered experimental as it requires enabling CFG80211_CERTIFICATION_ONUS [4]. 

There are lots of other repos out there for rtl8812au driver, but this is the only one that actually works with arm64/aarch64 (Raspi4+Ubuntu).


[1] https://github.com/aircrack-ng/rtl8812au/blob/65174c4ded74b2da982a13605db59bc0b643c187/os_dep/linux/wifi_regd.c#L259
[2] https://wireless.wiki.kernel.org/en/developers/regulatory/statement
[3] https://github.com/mk-fg/rtl8812au/blob/881375b5e2e0878e7628cc4c705de6fa2ace41ea/Realtek_Changelog.txt#L10
[4] https://github.com/torvalds/linux/blob/81160dda9a7aad13c04e78bb2cfd3c4630e3afab/net/wireless/Kconfig#L70
[5] https://wiki.gentoo.org/wiki/Hostapd#DFS
[6] https://phabricator.vyos.net/T452
[7] https://github.com/aircrack-ng/rtl8812au/issues/530