### PR TITLE
Update makefile for arm/arm64 detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -680,7 +680,7 @@ EXTRA_CFLAGS += -DDM_ODM_SUPPORT_TYPE=0x04
 ifeq ($(CONFIG_PLATFORM_I386_PC), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
 EXTRA_CFLAGS += -DRTW_USE_CFG80211_STA_EVENT
-SUBARCH := $(shell uname -m | sed -e s/i.86/i386/ | sed -e s/ppc64le/powerpc/)
+SUBARCH := $(shell uname -m | sed -e "s/i.86/i386/; s/ppc/powerpc/; s/armv.l/arm/; s/aarch64/arm64/;")
 ARCH ?= $(SUBARCH)
 CROSS_COMPILE ?=
 KVER  := $(shell uname -r)


### PR DESCRIPTION
Pull the line from 5.6.1 branch into 5.3.4 as that's what Kali ships currently.  This way, we don't have to patch the detection in, so it will correctly substitute ARCH on arm and arm64 devices.