### PR TITLE
Add RHEL 8 support and support for possible work on future RHEL releases

### DIFF
--- a/include/basic_types.h
+++ b/include/basic_types.h
@@ -72,6 +72,10 @@
 
 #ifdef PLATFORM_LINUX
 	#include <linux/version.h>
+	#ifndef RHEL_RELEASE_CODE
+	#define RHEL_RELEASE_VERSION(a,b) (((a) << 8) + (b))
+	#define RHEL_RELEASE_CODE 0
+	#endif
 	#include <linux/types.h>
 	#include <linux/module.h>
 	#include <linux/kernel.h>

--- a/include/osdep_service.h
+++ b/include/osdep_service.h
@@ -16,6 +16,10 @@
 #define __OSDEP_SERVICE_H_
 
 #include <linux/version.h>
+#ifndef RHEL_RELEASE_CODE
+#define RHEL_RELEASE_VERSION(a,b) (((a) << 8) + (b))
+#define RHEL_RELEASE_CODE 0
+#endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
 #include <linux/sched/signal.h>
 #endif

--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -16,6 +16,10 @@
 #define __OSDEP_LINUX_SERVICE_H_
 
 #include <linux/version.h>
+#ifndef RHEL_RELEASE_CODE
+#define RHEL_RELEASE_VERSION(a,b) (((a) << 8) + (b))
+#define RHEL_RELEASE_CODE 0
+#endif
 #include <linux/spinlock.h>
 #include <linux/compiler.h>
 #include <linux/kernel.h>

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1366,7 +1366,7 @@ unsigned int rtw_classify8021d(struct sk_buff *skb)
 
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
-	#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
+	#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8,0)
 	, struct net_device *sb_dev
 	#else
 	, void *accel_priv

--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -663,7 +663,7 @@ int rtw_android_priv_cmd(struct net_device *net, struct ifreq *ifr, int cmd)
 		ret = -ENOMEM;
 		goto exit;
 	}
-	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0))
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)) || (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8,0))
 	if (!access_ok(priv_cmd.buf, priv_cmd.total_len)) {
 	#else
 	if (!access_ok(VERIFY_READ, priv_cmd.buf, priv_cmd.total_len)) {

--- a/platform/platform_aml_s905_sdio.h
+++ b/platform/platform_aml_s905_sdio.h
@@ -16,6 +16,10 @@
 #define __PLATFORM_AML_S905_SDIO_H__
 
 #include <linux/version.h>	/* Linux vresion */
+#ifndef RHEL_RELEASE_CODE
+#define RHEL_RELEASE_VERSION(a,b) (((a) << 8) + (b))
+#define RHEL_RELEASE_CODE 0
+#endif
 
 extern void sdio_reinit(void);
 extern void extern_wifi_set_enable(int is_on);


### PR DESCRIPTION
I've added RHEL 8 support, but did it in a way that'll make it easier to support other, future changes for RHEL releases going forward.

If you'd prefer the changes are less invasive, let me know and I can just redo it for supporting just RHEL 8 builds for the moment.

I've build tested my changes also on Fedora 31 and Ubuntu 18.04 to ensure that there wasn't a glaring coding mistake in #ifdef'ing.

This problem will hopefully address Issues #542 and #598.