### PR TITLE
Check event_callback is not NULL before invoke

### DIFF
--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -15848,7 +15848,8 @@ u8 mlme_evt_hdl(_adapter *padapter, unsigned char *pbuf)
 
 	if (peventbuf) {
 		event_callback = wlanevents[evt_code].event_callback;
-		event_callback(padapter, (u8 *)peventbuf);
+		if (event_callback)
+			event_callback(padapter, (u8 *)peventbuf);
 
 		pevt_priv->evt_done_cnt++;
 	}


### PR DESCRIPTION
`wlanevents` defined in `include/rtw_mlme_ext.h` works like an event dispatch table.
I don't know whether realtek have some method to guarantee an event with null record never dispatched. I'm quite amazed this never happend on my x86_64 machines in my tests. But once tested on an openwrt router (mips ath79 linux 4.19.108 mac80211-backport 5.4) this happened and kernel crashed.