### PR TITLE
Remove FPU dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1166,16 +1166,16 @@ endif
 
 ifeq ($(CONFIG_MP_VHT_HW_TX_MODE), y)
 EXTRA_CFLAGS += -DCONFIG_MP_VHT_HW_TX_MODE
-ifeq ($(CONFIG_PLATFORM_I386_PC), y)
-## For I386 X86 ToolChain use Hardware FLOATING
-EXTRA_CFLAGS += -mhard-float
-EXTRA_CFLAGS += -DMARK_KERNEL_PFU
-else
-## For ARM ToolChain use Hardware FLOATING
-# Raspbian kernel is with soft-float.
-# 'softfp' allows FP instructions, but no FP on function call interfaces
-EXTRA_CFLAGS += -mfloat-abi=softfp
-endif
+# ifeq ($(CONFIG_PLATFORM_I386_PC), y)
+# ## For I386 X86 ToolChain use Hardware FLOATING
+# EXTRA_CFLAGS += -mhard-float
+# EXTRA_CFLAGS += -DMARK_KERNEL_PFU
+# else
+# ## For ARM ToolChain use Hardware FLOATING
+# # Raspbian kernel is with soft-float.
+# # 'softfp' allows FP instructions, but no FP on function call interfaces
+# EXTRA_CFLAGS += -mfloat-abi=softfp
+# endif
 endif
 
 ifeq ($(CONFIG_APPEND_VENDOR_IE_ENABLE), y)


### PR DESCRIPTION
This is work-in-progress sketchy attempt to replace floating-point used in `core/rtw_mp.c` with integer equivalence.
Although it works fine in my testcases, but I have no confidence about its correctness.
Please review, test, and comment.