### PR TITLE
Update Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: c
 compiler: gcc
-sudo: required
 dist: bionic
+os: linux
 
 before_install:
-  - export ALL_DEB=$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep -m1 all | cut -d '"' -f 2)
+  - export KERNEL_URL_DETAILS=$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -A8 'Build for amd64')
+  - export ALL_DEB=$(echo "$KERNEL_URL_DETAILS" |  grep -m1 'all.deb' | cut -d '"' -f 2)
   - export KVER_BUILD=$(echo $ALL_DEB | cut -d '_' -f 1 | cut -c15-)
-  - wget ${KERNEL_URL}v${KVER}/$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep headers | grep generic | grep -m1 amd64 | cut -d '"' -f 2)
+  - wget ${KERNEL_URL}v${KVER}/$(echo "$KERNEL_URL_DETAILS" | grep -m1 'amd64.deb' | cut -d '"' -f 2)
   - wget ${KERNEL_URL}v${KVER}/$ALL_DEB
   - sudo dpkg -i *.deb
 
@@ -14,53 +15,48 @@ script:
   - make CC=$COMPILER KVER=$KVER_BUILD-generic
 env:
   global:
-    - KERNEL_URL=http://kernel.ubuntu.com/~kernel-ppa/mainline/
+    - KERNEL_URL=https://kernel.ubuntu.com/~kernel-ppa/mainline/
 
-matrix:
+addons:
+  apt:
+    packages:
+      #Force update to GCC-7.5 in order to compile Kernels >= 5.4.
+      - gcc-7
+
+cache:
+  - ccache: true
+
+jobs:
   include:
-    - compiler: gcc
-      addons:
+    - addons:
         apt:
           sources:
             - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - gcc-9
-      env: COMPILER=gcc-9 KVER=5.6-rc5
-    - compiler: gcc
-      addons:
+      env: COMPILER=gcc-9 KVER=$(curl -s https://www.kernel.org/releases.json | grep 'mainline' -B1 | head -1 | cut -d'"' -f4)
+    - addons:
         apt:
           packages:
             - gcc-8
-      env: COMPILER=gcc-8 KVER=5.6-rc5
-    - compiler: gcc
-      env: COMPILER=gcc-7 KVER=5.6-rc5
-    - compiler: gcc
-      addons:
+      env: COMPILER=gcc-8 KVER=$(curl -s https://www.kernel.org/releases.json | grep 'mainline' -B1 | head -1 | cut -d'"' -f4)
+
+    - env: COMPILER=gcc-7 KVER=$(curl -s https://www.kernel.org/releases.json | grep 'mainline' -B1 | head -1 | cut -d'"' -f4)
+    - env: COMPILER=gcc-7 KVER=$(curl -s https://www.kernel.org/releases.json | grep -A1 'latest_stable' | tail -1 | cut -d'"' -f4)
+    - env: COMPILER=gcc-7 KVER=5.5.18
+ #Kernels 5.4 with minor versions > 28 are failing on amd64. Not upgrade the minor version without check https://kernel.ubuntu.com/~kernel-ppa/mainline/
+    - env: COMPILER=gcc-7 KVER=5.4.28
+    - env: COMPILER=gcc-7 KVER=4.19.116
+    - env: COMPILER=gcc-7 KVER=4.14.176
+    - env: COMPILER=gcc-7 KVER=4.9.219
+    - env: COMPILER=gcc-7 KVER=4.4.219
+
+#Version 4.15.x requested to test Ubuntu 18.04 LTS version
+#TODO identify 4.15.x version dynamically instead of hardcode it.
+    - addons:
         apt:
           packages:
-            - gcc-6
-      env: COMPILER=gcc-6 KVER=5.6-rc5
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - sourceline: "ppa:ubuntu-toolchain-r/test"
-          packages:
-            - gcc-9
-      env: COMPILER=gcc-9 KVER=4.19.93
-    - compiler: gcc
-      addons:
-        apt:
-          packages:
-            - gcc-8
-      env: COMPILER=gcc-8 KVER=4.19.93
-    - compiler: gcc
-      env: COMPILER=gcc-7 KVER=4.19.93
-    - compiler: gcc
-      addons:
-        apt:
-          packages:
-            - gcc-6
-      env: COMPILER=gcc-6 KVER=4.19.93
-    - compiler: gcc
-      env: COMPILER=gcc-7 KVER=4.15.18
+            - linux-headers-4.15.0-20-generic
+#Use the kernel headers from apt instead of download it from an external source
+      before_install: true
+      env: COMPILER=gcc-7 $KVER_BUILD=4.15.0-20


### PR DESCRIPTION
- Updated with all kernels from https://www.kernel.org/
- Kernel mainline version fetch from kernel.org instead of hardcode it.
- Fixed minor warnings on Travis configuration.
- Simplified URL extraction
- Removed GCC-6 from build matrix.

The change that calculate the kernel mainline version automatically can be controversial:

CONS
- Made the builds not reproducible at 100% (it's based on the value at kernel.org)

PROS
- Ensure that all PR are tested over the lasts kernel versions.
- No longer needs to made a PR to test the code with the last RC, it can be done using the Travis web interface. It's keep the commit history more clean. 

Feel free to requests changes.