### PR TITLE
4.3.21:fix RaspberryPi-4.19 build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,7 @@ CONFIG_PLATFORM_RTK119X = n
 CONFIG_PLATFORM_NOVATEK_NT72668 = n
 CONFIG_PLATFORM_HISILICON = n
 CONFIG_PLATFORM_ARM64 = n
+CONFIG_PLATFORM_ARM_RPI = n
 ###############################################################
 
 CONFIG_DRVEXT_MODULE = n
@@ -976,6 +977,16 @@ endif
 ARCH := arm
 CROSS_COMPILE := /opt/arm-2011.09/bin/arm-none-linux-gnueabi-
 KSRC := /home/android_sdk/Action-semi/705a_android_L/android/kernel
+endif
+
+ifeq ($(CONFIG_PLATFORM_ARM_RPI), y)
+EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+ARCH := arm
+CROSS_COMPILE := 
+KVER ?= $(shell uname -r)
+KSRC := /lib/modules/$(KVER)/build
+MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
 endif
 
 ifeq ($(CONFIG_PLATFORM_ARM_SUN50IW1P1), y)

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -798,14 +798,22 @@ unsigned int rtw_classify8021d(struct sk_buff *skb)
 	return dscp >> 5;
 }
 
- 
+#if (LINUX_VERSION_CODE>=KERNEL_VERSION(4,19,0))
+static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb,
+			struct net_device *sb_dev,
+			select_queue_fallback_t fallback
+#else
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0) 	
-				, void *accel_priv
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0) 
-				, select_queue_fallback_t fallback
-#endif
-
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
+  #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0)
+	  , void *accel_priv
+  #else
+    , struct net_device *sb_dev
+  #endif
+  #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(5, 2, 0))
+	  , select_queue_fallback_t fallback
+  #endif
+#endif			    
 #endif
 )
 {


### PR DESCRIPTION
Fix latest Raspberrypi build. The kernel version is: ```4.19.42-v7+```

Verified with RaspberryPi 3B and ASUS USB-AC56.