### PR TITLE
Bugfix: Phy cannot be moved into another namespace

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -9614,10 +9614,10 @@ struct ieee80211_supported_band *band;
 		wiphy->bands[NL80211_BAND_5GHZ] = rtw_spt_band_alloc(BAND_ON_5G);
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 38) && LINUX_VERSION_CODE < KERNEL_VERSION(3, 0, 0))
 #if defined(CONFIG_NET_NS)
 	wiphy->flags |= WIPHY_FLAG_NETNS_OK;
 #endif //CONFIG_NET_NS
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 38) && LINUX_VERSION_CODE < KERNEL_VERSION(3, 0, 0))
 	wiphy->flags |= WIPHY_FLAG_SUPPORTS_SEPARATE_DEFAULT_KEYS;
 #endif
 


### PR DESCRIPTION
When CONFIG_NET_NS is enabled one would assume the device can be moved into another namespace. Currently it will fail with:

`command failed: Operation not supported (-95)`

There's a check if the kernel is between 2.6.38 and 3.0.0 before it adds the netns flag to wiphy->flags.

With this commit it will always add the netns flag when CONFIG_NET_NS is enabled.

Signed-off-by: Daan van Gorkum <djvg@djvg.net>
Fixes: https://github.com/aircrack-ng/rtl8812au/issues/518