### PR TITLE
bugfix: initialize cfg80211_chan_def structure to zero to fix nl80211…

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -447,7 +447,7 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset,
 	u8 ret = _SUCCESS;
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
-	struct cfg80211_chan_def chdef;
+	struct cfg80211_chan_def chdef = {};
 
 	ret = rtw_chbw_to_cfg80211_chan_def(wiphy, &chdef, ch, bw, offset, ht);
 	if (ret != _SUCCESS)


### PR DESCRIPTION
…_send_chandef kernel trap

At present, the cfg80211_chan_def structure used in rtw_cfg80211_ch_switch_notify is uninitialized.  When the wireless driver starts up, it causes a kernel trap.  Here's an example from one of my arm64 boards:

    [   13.705940] ------------[ cut here ]------------
    [   13.706031] WARNING: CPU: 3 PID: 442 at net/wireless/nl80211.c:3297 nl80211_send_chandef+0x158/0x168 [cfg80211]
    [   13.706034] Modules linked in: zstd zram 88XXau sun8i_codec_analog sun4i_codec sun8i_adda_pr_regmap cfg80211 snd_soc_core lima sunxi_cedrus(C) rfkill gpu_sched sun4i_gpadc_iio snd_pcm_dmaengine snd_pcm industrialio v4l2_mem2mem snd_timer videobuf2_dma_contig snd videobuf2_memops soundcore videobuf2_v4l2 videobuf2_common videodev sun8i_ce crypto_engine mc cpufreq_dt realtek sy8106a_regulator spidev spi_gpio spi_bitbang dwmac_sun8i i2c_mv64xxx mdio_mux
    [   13.706101] CPU: 3 PID: 442 Comm: RTW_CMD_THREAD Tainted: G         C        5.7.14-sunxi64 #trunk
    [   13.706103] Hardware name: FriendlyARM NanoPi NEO Core2 (DT)
    [   13.706109] pstate: 40000005 (nZcv daif -PAN -UAO)
    [   13.706125] pc : nl80211_send_chandef+0x158/0x168 [cfg80211]
    [   13.706137] lr : nl80211_send_chandef+0x34/0x168 [cfg80211]
    [   13.706140] sp : ffff8000114c3c20
    [   13.706141] x29: ffff8000114c3c20 x28: ffff000034542600
    [   13.706145] x27: ffff800008f4add0 x26: 0000000000000000
    [   13.706148] x25: ffff8000114c3d48 x24: ffff0000345f9000
    [   13.706152] x23: ffff0000345f8100 x22: ffff000033d3cf80
    [   13.706155] x21: ffff000033552014 x20: ffff000033c29f00
    [   13.706159] x19: ffff8000114c3d48 x18: 0000000000000000
    [   13.706163] x17: 0000000000000000 x16: 0000000000000000
    [   13.706166] x15: 0000000000000000 x14: 040595163d000000
    [   13.706169] x13: 0000000000000000 x12: ffff80001147d7ec
    [   13.706173] x11: ffff80001147dc62 x10: 000000000000000a
    [   13.706176] x9 : 000000000000003b x8 : ffff00003355201c
    [   13.706179] x7 : 0000000000000000 x6 : ffff00003355201c
    [   13.706183] x5 : 0000000000000000 x4 : 0000000000001671
    [   13.706186] x3 : 000000000000168f x2 : 0000000000000000
    [   13.706190] x1 : 000000001147d7ed x0 : 0000000000000000
    [   13.706195] Call trace:
    [   13.706211]  nl80211_send_chandef+0x158/0x168 [cfg80211]
    [   13.706223]  nl80211_ch_switch_notify.isra.0.constprop.0+0xec/0x180 [cfg80211]
    [   13.706238]  cfg80211_ch_switch_started_notify+0x30/0x40 [cfg80211]
    [   13.706451]  rtw_cfg80211_ch_switch_notify+0x12c/0x158 [88XXau]
    [   13.706521]  join_cmd_hdl+0x260/0x398 [88XXau]
    [   13.706568]  rtw_cmd_thread+0x2f4/0x498 [88XXau]
    [   13.706580]  kthread+0xf4/0x120
    [   13.706586]  ret_from_fork+0x10/0x30
    [   13.706591] ---[ end trace 17a2bfbedc1b3409 ]---

This change initializes the structure to zero, eliminating the kernel trap.
