### PR TITLE
rtl8812au: Fix driver startup traps

### DIFF
--- a/core/rtw_ap.c
+++ b/core/rtw_ap.c
@@ -1804,7 +1804,8 @@ chbw_decision:
 				, pdvobj->padapters[i]->mlmeextpriv.cur_channel
 				, pdvobj->padapters[i]->mlmeextpriv.cur_bwmode
 				, pdvobj->padapters[i]->mlmeextpriv.cur_ch_offset
-				, ht_option);
+				, ht_option
+				, 0);
 		}
 	}
 #endif /* defined(CONFIG_IOCTL_CFG80211) && (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0)) */

--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -16110,7 +16110,8 @@ void rtw_join_done_chk_ch(_adapter *adapter, int join_res)
 
 						rtw_cfg80211_ch_switch_notify(iface
 							, mlmeext->cur_channel, mlmeext->cur_bwmode, mlmeext->cur_ch_offset
-							, ht_option);
+							, ht_option
+							, 0);
 						#endif
 					}
 				}
@@ -16328,7 +16329,7 @@ exit:
 				the bss freq is updated by channel switch event.
 			*/
 			rtw_cfg80211_ch_switch_notify(adapter,
-				cur_ch, cur_bw, cur_ch_offset, ht_option);
+				cur_ch, cur_bw, cur_ch_offset, ht_option, 1);
 		}
 #endif
 	}

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -407,17 +407,25 @@ static void rtw_get_chbw_from_nl80211_channel_type(struct ieee80211_channel *cha
 #endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29)) */
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0))
-u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset, u8 ht)
+u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset,
+	u8 ht, bool started)
 {
 	struct wiphy *wiphy = adapter_to_wiphy(adapter);
 	u8 ret = _SUCCESS;
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
-	struct cfg80211_chan_def chdef;
+	struct cfg80211_chan_def chdef = {};
 
 	ret = rtw_chbw_to_cfg80211_chan_def(wiphy, &chdef, ch, bw, offset, ht);
 	if (ret != _SUCCESS)
 		goto exit;
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0))
+	if (started) {
+		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0);
+		goto exit;
+	}
+#endif
 
 	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef);
 

--- a/os_dep/linux/ioctl_cfg80211.h
+++ b/os_dep/linux/ioctl_cfg80211.h
@@ -407,7 +407,7 @@ void rtw_cfg80211_deinit_rfkill(struct wiphy *wiphy);
 #endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0))
-u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset, u8 ht);
+u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset, u8 ht, bool started);
 #endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 26)) && (LINUX_VERSION_CODE < KERNEL_VERSION(4, 7, 0))


### PR DESCRIPTION
These changes are a forward-port of associated previous changes in the v5.6.4.2 driver to the v5.7.0 driver.  They correct problems in the driver initialization process that caused multiple kernel traps on startup.

Here is an example of the two kernel traps that occur prior to these changes (this is using kernel 5.7.15 on an arm64 board):

    [   11.413349] ------------[ cut here ]------------
    [   11.413419] WARNING: CPU: 2 PID: 496 at net/wireless/nl80211.c:16683 cfg80211_ch_switch_notify+0xac/0xb8 [cfg80211]
    [   11.413423] Modules linked in: zstd zram 88XXau sun8i_codec_analog sun4i_codec sun8i_adda_pr_regmap snd_soc_core snd_pcm_dmaengine snd_pcm cfg80211 sun4i_gpadc_iio snd_timer lima rfkill snd industrialio soundcore gpu_sched sunxi_cedrus(C) v4l2_mem2mem videobuf2_dma_contig videobuf2_memops sun8i_ce videobuf2_v4l2 videobuf2_common crypto_engine videodev mc cpufreq_dt realtek spidev sy8106a_regulator spi_gpio i2c_mv64xxx spi_bitbang dwmac_sun8i mdio_mux
    [   11.413484] CPU: 2 PID: 496 Comm: RTW_CMD_THREAD Tainted: G         C        5.7.15-sunxi64 #trunk
    [   11.413487] Hardware name: FriendlyARM NanoPi NEO Core2 (DT)
    [   11.413492] pstate: 60000005 (nZCv daif -PAN -UAO)
    [   11.413507] pc : cfg80211_ch_switch_notify+0xac/0xb8 [cfg80211]
    [   11.413702] lr : rtw_cfg80211_ch_switch_notify+0xe8/0x138 [88XXau]
    [   11.413704] sp : ffff800011953cd0
    [   11.413707] x29: ffff800011953cd0 x28: ffff8000090c5430
    [   11.413710] x27: ffff800008f86f00 x26: 0000000000000003
    [   11.413714] x25: ffff000009b4c300 x24: 0000000000000001
    [   11.413717] x23: 0000000000000001 x22: 0000000000000002
    [   11.413721] x21: ffff000009b4b000 x20: ffff000009b4c000
    [   11.413724] x19: ffff800011953d58 x18: 0000000000000000
    [   11.413728] x17: 0000000000000000 x16: 0000000000000000
    [   11.413731] x15: 0000000000000000 x14: 0000000000000008
    [   11.413734] x13: 7f0201c7fffc009b x12: 0105c001b2fffe01
    [   11.413738] x11: 0000000000000004 x10: 0000000000000002
    [   11.413741] x9 : 0000000000000004 x8 : 0000000000000006
    [   11.413745] x7 : 0000000000000040 x6 : ffff000009b4c420
    [   11.413748] x5 : ffff0000337720f8 x4 : ffff000033772118
    [   11.413751] x3 : ffff800011953d90 x2 : a7def39300000000
    [   11.413754] x1 : 0000000000000000 x0 : ffff000033772000
    [   11.413759] Call trace:
    [   11.413776]  cfg80211_ch_switch_notify+0xac/0xb8 [cfg80211]
    [   11.413868]  rtw_cfg80211_ch_switch_notify+0xe8/0x138 [88XXau]
    [   11.413926]  rtw_chk_start_clnt_join+0x70/0x80 [88XXau]
    [   11.413982]  join_cmd_hdl+0x240/0x34c [88XXau]
    [   11.414037]  rtw_cmd_thread+0x2b8/0x424 [88XXau]
    [   11.414046]  kthread+0xf4/0x120
    [   11.414053]  ret_from_fork+0x10/0x30
    [   11.414056] ---[ end trace b4e3ae332c587b47 ]---
    [   11.414299] ------------[ cut here ]------------
    [   11.414344] WARNING: CPU: 2 PID: 496 at net/wireless/nl80211.c:3297 nl80211_send_chandef+0x158/0x168 [cfg80211]
    [   11.414347] Modules linked in: zstd zram 88XXau sun8i_codec_analog sun4i_codec sun8i_adda_pr_regmap snd_soc_core snd_pcm_dmaengine snd_pcm cfg80211 sun4i_gpadc_iio snd_timer lima rfkill snd industrialio soundcore gpu_sched sunxi_cedrus(C) v4l2_mem2mem videobuf2_dma_contig videobuf2_memops sun8i_ce videobuf2_v4l2 videobuf2_common crypto_engine videodev mc cpufreq_dt realtek spidev sy8106a_regulator spi_gpio i2c_mv64xxx spi_bitbang dwmac_sun8i mdio_mux
    [   11.414399] CPU: 2 PID: 496 Comm: RTW_CMD_THREAD Tainted: G        WC        5.7.15-sunxi64 #trunk
    [   11.414401] Hardware name: FriendlyARM NanoPi NEO Core2 (DT)
    [   11.414405] pstate: 40000005 (nZcv daif -PAN -UAO)
    [   11.414418] pc : nl80211_send_chandef+0x158/0x168 [cfg80211]
    [   11.414431] lr : nl80211_send_chandef+0x34/0x168 [cfg80211]
    [   11.414433] sp : ffff800011953c20
    [   11.414434] x29: ffff800011953c20 x28: ffff8000090c5430
    [   11.414438] x27: ffff800008edadd0 x26: 0000000000000000
    [   11.414442] x25: ffff800011953d58 x24: ffff000009b4c000
    [   11.414445] x23: ffff000009b4b100 x22: ffff000035c65cc0
    [   11.414452] x21: ffff0000354ad014 x20: ffff000033115300
    [   11.414464] x19: ffff800011953d58 x18: 0000000000000000
    [   11.414472] x17: 0000000000000000 x16: 0000000000000000
    [   11.414480] x15: 0000000000000000 x14: 00000000000002de
    [   11.414489] x13: 7f0201c7fffc009b x12: 0000000000000001
    [   11.414493] x11: 0000000000000000 x10: 0000000000000003
    [   11.414496] x9 : 00000000000002f5 x8 : ffff0000354ad01c
    [   11.414500] x7 : 0000000000000000 x6 : ffff0000354ad01c
    [   11.414503] x5 : 0000000000000000 x4 : 00000000ffff32a1
    [   11.414506] x3 : 0000000000002e68 x2 : 0000000000000093
    [   11.414509] x1 : 0000000011953d90 x0 : 0000000000000000
    [   11.414513] Call trace:
    [   11.414528]  nl80211_send_chandef+0x158/0x168 [cfg80211]
    [   11.414541]  nl80211_ch_switch_notify.isra.0.constprop.0+0xec/0x180 [cfg80211]
    [   11.414553]  cfg80211_ch_switch_notify+0x80/0xb8 [cfg80211]
    [   11.414667]  rtw_cfg80211_ch_switch_notify+0xe8/0x138 [88XXau]
    [   11.414734]  rtw_chk_start_clnt_join+0x70/0x80 [88XXau]
    [   11.414792]  join_cmd_hdl+0x240/0x34c [88XXau]
    [   11.414849]  rtw_cmd_thread+0x2b8/0x424 [88XXau]
    [   11.414861]  kthread+0xf4/0x120
    [   11.414869]  ret_from_fork+0x10/0x30
    [   11.414874] ---[ end trace b4e3ae332c587b48 ]---

With these changes both of these kernel traps are eliminated at driver startup.
