### PR TITLE
fix Kconfig compatibility for kernel v5.9

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1,6 +1,6 @@
 config 88XXAU
 	tristate "Realtek 88XXau USB WiFi"
 	depends on USB
-	---help---
+	help
 	  Help message of 88XXau
 


### PR DESCRIPTION
With kernel v5.9, support for the "---help---" keyword in Kconfig has been removed (see https://github.com/torvalds/linux/commit/f70f74d15ca80d73eca6d5a731257627fb6370c5).  This change corrects the help keyword in the Kconfig of this driver.

(BTW this driver is working quite well for me under kernel v5.9-rc2!)