### PR TITLE
fix Kconfig compatibility for kernel v5.9

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1,6 +1,6 @@
 config 88XXAU
 	tristate "Realtek 88XXau USB WiFi"
 	depends on USB
-	---help---
+	help
 	  Support for 8812au, 8821au and 8814au
 


### PR DESCRIPTION
With kernel v5.9, support for the "---help---" keyword in Kconfig has been removed (see https://github.com/torvalds/linux/commit/f70f74d15ca80d73eca6d5a731257627fb6370c5). This simple change corrects the help keyword specified in the Kconfig of this driver so that the driver can be properly compiled.
