### PR TITLE
fix: resolve "missing )" error from make when doing dkms_install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2416,7 +2416,7 @@ config_r:
 	@echo "make config"
 	/bin/bash script/Configure script/config.in
 
-DRIVER_VERSION = $(shell grep "#define DRIVERVERSION" include/rtw_version.h | awk '{print $$3}' | tr -d v\")
+DRIVER_VERSION = $(shell grep "\#define DRIVERVERSION" include/rtw_version.h | awk '{print $$3}' | tr -d v\")
 
 dkms_install:
 	mkdir -p /usr/src/8812au-$(DRIVER_VERSION)


### PR DESCRIPTION
This hopefully resolves https://github.com/aircrack-ng/rtl8812au/issues/802 for the v5.7.0 branch, although other branches may need the same fix.