### PR TITLE
Fix error on arm builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2130,14 +2130,6 @@ EXTRA_CFLAGS += -DMARK_KERNEL_PFU
 else ifeq ($(ARCH), x86_64)
 EXTRA_CFLAGS += -mhard-float
 EXTRA_CFLAGS += -DMARK_KERNEL_PFU
-else ifeq ($(ARCH), arm)
-# Raspbian kernel is with soft-float.
-# 'softfp' allows FP instructions, but no FP on function call interfaces
-ifeq ($(CONFIG_PLATFORM_ARM_RPI), y)
-EXTRA_CFLAGS += -mfloat-abi=softfp
-else
-EXTRA_CFLAGS += -mfloat-abi=hard
-endif
 endif
 
 ########### CUSTOMER ################################


### PR DESCRIPTION
Fix errors described on #802

CONFIG_PLATFORM_ARM_RPI functionality not change just moved to another place.

Removed the hardcoded value of -mfloat-abi=hard for ARM builds.

Tested with Libreelec builds on ARM and ARM64 but maybe more testing is needed on other scenarios.

CC/
@pprindeville
@danieletorelli
@solsticedhiver
@yasij 
@tomty89

For additional testing on other environments.

Related to #804 and #802