### PR TITLE
Fix error creating an access point below channel 36

### DIFF
--- a/core/rtw_ap.c
+++ b/core/rtw_ap.c
@@ -4507,12 +4507,14 @@ static u8 rtw_ap_ch_specific_chk(_adapter *adapter, u8 ch, u8 *bw, u8 *offset, c
 	RT_CHANNEL_INFO *chset = adapter_to_chset(adapter);
 	u8 ret = _SUCCESS;
 
+	// ignore reg domain check
+#if 0
 	if (rtw_chset_search_ch(chset, ch) < 0) {
 		RTW_WARN("%s ch:%u doesn't fit in chplan\n", caller, ch);
 		ret = _FAIL;
 		goto exit;
 	}
-
+#endif
 	rtw_adjust_chbw(adapter, ch, bw, offset);
 
 	if (!rtw_get_offset_by_chbw(ch, *bw, offset)) {

--- a/core/rtw_rf.c
+++ b/core/rtw_rf.c
@@ -451,7 +451,7 @@ int rtw_ch2freq(int chan)
 			return 2484;
 		else if (chan < 14)
 			return 2407 + chan * 5;
-	} else if (chan >= 36 && chan <= 177)
+	} else if (chan >= 15 && chan <= 177)
 		return 5000 + chan * 5;
 
 	return 0; /* not supported */


### PR DESCRIPTION
Fix issue reported by Zanzaux (https://github.com/aircrack-ng/rtl8812au/issues/817#issuecomment-774428545)