### PR TITLE
Fix GRO_DROP deprecation kernel 5.12

### DIFF
--- a/os_dep/linux/recv_linux.c
+++ b/os_dep/linux/recv_linux.c
@@ -355,8 +355,12 @@ static int napi_recv(_adapter *padapter, int budget)
 
 #ifdef CONFIG_RTW_GRO
 		if (pregistrypriv->en_gro) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 12, 0)
 			if (rtw_napi_gro_receive(&padapter->napi, pskb) != GRO_DROP)
 				rx_ok = _TRUE;
+#else
+			rx_ok = _TRUE;
+#endif
 			goto next;
 		}
 #endif /* CONFIG_RTW_GRO */


### PR DESCRIPTION
See https://github.com/torvalds/linux/commit/38f7b449256490c312e4e83101075201fb5f87d1

Only tested on compilation, not on real hardware.