### PR TITLE
Implement actions/stale@v3 to close issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: 'Close stale issues'
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-label: 'area: stale'
+          stale-issue-message: |
+            This issue is stale because it has been open 30 days with no activity.
+            Our core developers tend to be more verbose on denying. If there is no negative comment, possibly this feature will be accepted.
+            We are accepting PRs :smiley:.
+            Comment or this will be closed in 7 days
+          days-before-stale: 30
+          days-before-close: 7


### PR DESCRIPTION
Untested, quick PR from Github Web UI.

Copy/pasted from 
https://github.com/jhipster/generator-jhipster/blob/main/.github/workflows/stale.yml

Just o avoid keep mode than 190+ issues open.

@kimocoder Let me now if you are interested on merge this and will take a look to "repo-token" property, I keep it as Draft from now.