### PR TITLE
Remove REMAKE_INITRD

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -7,4 +7,3 @@ PROCS_NUM=`nproc`
 DEST_MODULE_LOCATION[0]="/updates"
 MAKE="'make' -j$PROCS_NUM KVER=${kernelver} KSRC=/lib/modules/${kernelver}/build"
 AUTOINSTALL="yes"
-REMAKE_INITRD=no


### PR DESCRIPTION
Setting `REMAKE_INITRD=no` was not needed because it was the default, but since v3.0.0 [this option has been deprecated](https://github.com/dell/dkms/releases/tag/v3.0.0).
