### PR TITLE
rtl8812au: Fix builds with kernel 5.18

### DIFF
--- a/include/ieee80211.h
+++ b/include/ieee80211.h
@@ -1616,18 +1616,18 @@ enum ieee80211_state {
 	(((Addr[2]) & 0xff) == 0xff) && (((Addr[3]) & 0xff) == 0xff) && (((Addr[4]) & 0xff) == 0xff) && \
 				     (((Addr[5]) & 0xff) == 0xff))
 #else
-extern __inline int is_multicast_mac_addr(const u8 *addr)
+static inline int is_multicast_mac_addr(const u8 *addr)
 {
 	return (addr[0] != 0xff) && (0x01 & addr[0]);
 }
 
-extern __inline int is_broadcast_mac_addr(const u8 *addr)
+static inline int is_broadcast_mac_addr(const u8 *addr)
 {
 	return ((addr[0] == 0xff) && (addr[1] == 0xff) && (addr[2] == 0xff) &&   \
 		(addr[3] == 0xff) && (addr[4] == 0xff) && (addr[5] == 0xff));
 }
 
-extern __inline int is_zero_mac_addr(const u8 *addr)
+static inline int is_zero_mac_addr(const u8 *addr)
 {
 	return ((addr[0] == 0x00) && (addr[1] == 0x00) && (addr[2] == 0x00) &&   \
 		(addr[3] == 0x00) && (addr[4] == 0x00) && (addr[5] == 0x00));


### PR DESCRIPTION
Error during compile of kernel 5.18 with
- https://github.com/LibreELEC/LibreELEC.tv/pull/6423

```
/var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-ld: /var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-Generic.x86_64-11.0-devel/build/RTL8192DU-eb09a4e6e96a5a033afe60c71022bfa42eea148a/core/rtw_security.o: in function `is_multicast_mac_addr':
rtw_security.c:(.text+0x23e0): multiple definition of `is_multicast_mac_addr'; /var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-Generic.x86_64-11.0-devel/build/RTL8192DU-eb09a4e6e96a5a033afe60c71022bfa42eea148a/core/rtw_cmd.o:rtw_cmd.c:(.text+0x2c): first defined here
```

- Issue: https://github.com/lwfinger/rtl8192du/issues/91
- Fixed at: https://github.com/lwfinger/rtl8192du/commit/a4e32040416d2dba2611a8f410a4f7663a425eb3

reading
- https://lore.kernel.org/lkml/20190116132010.31395-1-natechancellor@gmail.com/
