### PR TITLE
Partial fix of CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,6 @@ jobs:
 
   build:
     needs: commontasks
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix: 
@@ -37,6 +36,7 @@ jobs:
             version: $(uname -r)
             use_apt: true
 
+    runs-on: ubuntu-22.04
     steps:
     - name: install deb packages
       env: 
@@ -51,7 +51,6 @@ jobs:
         [  -z "$AMD64_DEB" ] && exit 2
         wget -nv ${KERNEL_URL}v${VERSION}/$AMD64_DEB
         wget -nv ${KERNEL_URL}v${VERSION}/$ALL_DEB
-        wget -nv http://mirrors.edge.kernel.org/ubuntu/pool/main/g/glibc/libc6_2.34-0ubuntu3_amd64.deb
         sudo dpkg --force-all -i *.deb
         echo "KVER=$(echo $ALL_DEB | cut -d '_' -f 2 | rev | cut -c14- | rev)-generic" >> $GITHUB_ENV
     - name: apt-linux-headers


### PR DESCRIPTION
Last changes from https://kernel.ubuntu.com/~kernel-ppa/mainline/  in the way to complile the linux kernel cause the following error:
`gcc: error: unrecognized command line option ‘-mharden-sls=all’
`

This PR change the Ubuntu runner to align it to the ones used by Ubuntu kernel-ppa
`The kernel was built by: gcc (Ubuntu 11.2.0-1)`

Also the workaround for libc6 has been removed (already on 22.04 LTS)
