### PR TITLE
Fix for for corrupted device name

### DIFF
--- a/include/drv_types_linux.h
+++ b/include/drv_types_linux.h
@@ -16,7 +16,7 @@
 #define __DRV_TYPES_LINUX_H__
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0))
-#define dev_addr_set(netdev, ethdata) _rtw_memcpy(netdev, ethdata, ETH_ALEN) 
+#define dev_addr_set(netdev, ethdata) _rtw_memcpy(netdev->dev_addr, ethdata, ETH_ALEN) 
 #endif
 
 #endif


### PR DESCRIPTION
The macro definition for kernels < 5.15 is changed so that it is consistent with usage prior #961. Change should not affect compilation for newer kernels.

According to discussion in issue #969 the fix worked for at least a few users. I suspect this may be the cause of other 'not loading' and device name issues.
