### PR TITLE
Makefile: set check for two way path's

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ EXTRA_CFLAGS += -Wno-vla -g
 #EXTRA_CFLAGS += -Wno-date-time	# Fix compile error && warning on gcc 4.9 and later
 #endif
 
-EXTRA_CFLAGS += -I$(src)/include
+EXTRA_CFLAGS += -I$(src)/include -I$(srctree)/$(src)/include
+EXTRA_CFLAGS += -I$(src)/hal/phydm -I$(srctree)/$(src)/hal/phydm
 EXTRA_LDFLAGS += --strip-all -O3
 
 ########################## WIFI IC ############################
@@ -230,10 +231,10 @@ _HAL_INTFS_FILES :=	hal/hal_intf.o \
 			hal/led/hal_$(HCI_NAME)_led.o
 
 
-EXTRA_CFLAGS += -I$(src)/platform
+EXTRA_CFLAGS += -I$(src)/platform -I$(srctree)/$(src)/platform
 _PLATFORM_FILES := platform/platform_ops.o
 
-EXTRA_CFLAGS += -I$(src)/hal/btc
+EXTRA_CFLAGS += -I$(src)/hal/btc -I$(srctree)/$(src)/hal/btc
 
 
 ########### HAL_RTL8812A_RTL8821A #################################


### PR DESCRIPTION
this will avoid  error when building standalone or in kernel versions like 5.4