### PR TITLE
fix cfi trip from usb_recv_tasklet

### DIFF
--- a/include/usb_ops_linux.h
+++ b/include/usb_ops_linux.h
@@ -89,7 +89,7 @@ int usb_write16(struct intf_hdl *pintfhdl, u32 addr, u16 val);
 int usb_write32(struct intf_hdl *pintfhdl, u32 addr, u32 val);
 int usb_writeN(struct intf_hdl *pintfhdl, u32 addr, u32 length, u8 *pdata);
 u32 usb_read_port(struct intf_hdl *pintfhdl, u32 addr, u32 cnt, u8 *rmem);
-void usb_recv_tasklet(void *priv);
+void usb_recv_tasklet(unsigned long priv);
 
 #ifdef CONFIG_USB_INTERRUPT_IN_PIPE
 void usb_read_interrupt_complete(struct urb *purb, struct pt_regs *regs);

--- a/include/xmit_osdep.h
+++ b/include/xmit_osdep.h
@@ -67,8 +67,8 @@ struct sta_xmit_priv;
 struct xmit_frame;
 struct xmit_buf;
 
-extern int _rtw_xmit_entry(_pkt *pkt, _nic_hdl pnetdev);
-extern int rtw_xmit_entry(_pkt *pkt, _nic_hdl pnetdev);
+extern netdev_tx_t _rtw_xmit_entry(struct sk_buff *pkt, struct net_device *pnetdev);
+extern netdev_tx_t rtw_xmit_entry(struct sk_buff *pkt, struct net_device *pnetdev);
 
 #endif /* PLATFORM_LINUX */
 

--- a/os_dep/linux/usb_ops_linux.c
+++ b/os_dep/linux/usb_ops_linux.c
@@ -724,7 +724,7 @@ void usb_init_recvbuf(_adapter *padapter, struct recv_buf *precvbuf)
 int recvbuf2recvframe(PADAPTER padapter, void *ptr);
 
 #ifdef CONFIG_USE_USB_BUFFER_ALLOC_RX
-void usb_recv_tasklet(void *priv)
+void usb_recv_tasklet(unsigned long priv)
 {
 	struct recv_buf *precvbuf = NULL;
 	_adapter	*padapter = (_adapter *)priv;
@@ -862,7 +862,7 @@ u32 usb_read_port(struct intf_hdl *pintfhdl, u32 addr, u32 cnt, u8 *rmem)
 }
 #else	/* CONFIG_USE_USB_BUFFER_ALLOC_RX */
 
-void usb_recv_tasklet(void *priv)
+void usb_recv_tasklet(unsigned long priv)
 {
 	_pkt			*pskb;
 	_adapter		*padapter = (_adapter *)priv;

--- a/os_dep/linux/xmit_linux.c
+++ b/os_dep/linux/xmit_linux.c
@@ -444,7 +444,7 @@ int rtw_mlcst2unicst(_adapter *padapter, struct sk_buff *skb)
 #endif /* CONFIG_TX_MCAST2UNI */
 
 
-int _rtw_xmit_entry(_pkt *pkt, _nic_hdl pnetdev)
+netdev_tx_t _rtw_xmit_entry(struct sk_buff *pkt, struct net_device *pnetdev)
 {
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(pnetdev);
 	struct xmit_priv *pxmitpriv = &padapter->xmitpriv;
@@ -544,11 +544,11 @@ exit:
 	return 0;
 }
 
-int rtw_xmit_entry(_pkt *pkt, _nic_hdl pnetdev)
+netdev_tx_t rtw_xmit_entry(struct sk_buff *pkt, struct net_device *pnetdev)
 {
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(pnetdev);
 	struct	mlme_priv	*pmlmepriv = &(padapter->mlmepriv);
-	int ret = 0;
+	netdev_tx_t ret = NETDEV_TX_OK;
 
 	if (pkt) {
 		if (check_fwstate(pmlmepriv, WIFI_MONITOR_STATE) == _TRUE) {


### PR DESCRIPTION
Allows using monitor mode on devices with cfi enabled e.g. android builds.