### PR TITLE
Fix compiler and kernel warnings

### DIFF
--- a/core/rtw_br_ext.c
+++ b/core/rtw_br_ext.c
@@ -137,7 +137,9 @@ static __inline__ int __nat25_add_pppoe_tag(struct sk_buff *skb, struct pppoe_ta
 	/* have a room for new tag */
 	memmove(((unsigned char *)ph->tag + data_len), (unsigned char *)ph->tag, ntohs(ph->length));
 	ph->length = htons(ntohs(ph->length) + data_len);
+#pragma GCC diagnostic ignored "-Wstringop-overread"
 	memcpy((unsigned char *)ph->tag, tag, data_len);
+#pragma GCC diagnostic pop
 	return data_len;
 }
 

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -1156,7 +1156,8 @@ check_bss:
 
 		#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
-		roam_info.links[0].bssid = cur_network->network.MacAddress;
+		roam_info.links[0].channel = notify_channel;
+                roam_info.links[0].bssid = cur_network->network.MacAddress;
 #else
 		roam_info.bssid = cur_network->network.MacAddress;
 #endif
@@ -1190,13 +1191,17 @@ check_bss:
 		RTW_INFO("pwdev->sme_state(b)=%d\n", pwdev->sme_state);
 		#endif
 
-		if (check_fwstate(pmlmepriv, WIFI_MONITOR_STATE) != _TRUE)
-			rtw_cfg80211_connect_result(pwdev, cur_network->network.MacAddress
-				, pmlmepriv->assoc_req + sizeof(struct rtw_ieee80211_hdr_3addr) + 2
-				, pmlmepriv->assoc_req_len - sizeof(struct rtw_ieee80211_hdr_3addr) - 2
-				, pmlmepriv->assoc_rsp + sizeof(struct rtw_ieee80211_hdr_3addr) + 6
-				, pmlmepriv->assoc_rsp_len - sizeof(struct rtw_ieee80211_hdr_3addr) - 6
-				, WLAN_STATUS_SUCCESS, GFP_ATOMIC);
+		if (check_fwstate(pmlmepriv, WIFI_MONITOR_STATE) != _TRUE) {
+                        roam_info.links[0].bss = cfg80211_get_bss(pwdev->wiphy, roam_info.links[0].channel,
+                                roam_info.links[0].bssid, pwdev->u.client.ssid, pwdev->u.client.ssid_len,
+                                pwdev->conn_bss_type, IEEE80211_PRIVACY_ANY);
+			cfg80211_connect_bss(wdev_to_ndev(pwdev), cur_network->network.MacAddress, roam_info.links[0].bss
+                                , pmlmepriv->assoc_req + sizeof(struct rtw_ieee80211_hdr_3addr) + 2
+                                , pmlmepriv->assoc_req_len - sizeof(struct rtw_ieee80211_hdr_3addr) - 2
+                                , pmlmepriv->assoc_rsp + sizeof(struct rtw_ieee80211_hdr_3addr) + 6
+                                , pmlmepriv->assoc_rsp_len - sizeof(struct rtw_ieee80211_hdr_3addr) - 6
+                                , WLAN_STATUS_SUCCESS, GFP_ATOMIC, NL80211_TIMEOUT_UNSPECIFIED);
+                }
 		#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 11, 0) || defined(COMPAT_KERNEL_RELEASE)
 		RTW_INFO("pwdev->sme_state(a)=%d\n", pwdev->sme_state);
 		#endif

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -1192,10 +1192,10 @@ check_bss:
 		#endif
 
 		if (check_fwstate(pmlmepriv, WIFI_MONITOR_STATE) != _TRUE) {
-                        roam_info.links[0].bss = cfg80211_get_bss(pwdev->wiphy, roam_info.links[0].channel,
-                                roam_info.links[0].bssid, pwdev->u.client.ssid, pwdev->u.client.ssid_len,
-                                pwdev->conn_bss_type, IEEE80211_PRIVACY_ANY);
-			cfg80211_connect_bss(wdev_to_ndev(pwdev), cur_network->network.MacAddress, roam_info.links[0].bss
+                        struct cfg80211_bss *bss;
+                        bss = cfg80211_get_bss(pwdev->wiphy, NULL, cur_network->network.MacAddress, NULL, 0,
+                                IEEE80211_BSS_TYPE_ANY, IEEE80211_PRIVACY_ANY);
+                        cfg80211_connect_bss(wdev_to_ndev(pwdev), cur_network->network.MacAddress, bss
                                 , pmlmepriv->assoc_req + sizeof(struct rtw_ieee80211_hdr_3addr) + 2
                                 , pmlmepriv->assoc_req_len - sizeof(struct rtw_ieee80211_hdr_3addr) - 2
                                 , pmlmepriv->assoc_rsp + sizeof(struct rtw_ieee80211_hdr_3addr) + 6


### PR DESCRIPTION
Fix compiler (rtw_br_ext.c:969:11) and kernel (net/wireless/sme.c:843) warnings

I have TP-Link TL-WN722N Realtek RTL8188EUS and I can't test 8812au driver, but since codebase is similar I've pulled patches from https://github.com/gglluukk/rtl8188eus.
