### PR TITLE
Add 056E:4010 for elecom WDC-433DU2H2-B

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -197,6 +197,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE(0x056E, 0x4007), .driver_info = RTL8821}, /* Elecom - WDC-433DU2HBK */
 	{USB_DEVICE(0x056E, 0x400E), .driver_info = RTL8821}, /* ELECOM -  ELECOM */
 	{USB_DEVICE(0x056E, 0x400F), .driver_info = RTL8821}, /* ELECOM -  ELECOM */
+	{USB_DEVICE(0x056E, 0x4010), .driver_info = RTL8821}, /* ELECOM -  ELECOM */
 	{USB_DEVICE(0x0846, 0x9052), .driver_info = RTL8821}, /* Netgear - A6100 */
 	{USB_DEVICE(0x0E66, 0x0023), .driver_info = RTL8821}, /* HAWKING - Edimax */
 	{USB_DEVICE(0x2001, 0x3314), .driver_info = RTL8821}, /* D-Link - Cameo */


### PR DESCRIPTION
Thank you for sharing the useful program.
I want you to add a usb config to support [elecom device WDC-433DU2H2-B](https://www.elecom.co.jp/products/WDC-433DU2H2-B.html).

```sh
lsusb
Bus 002 Device 055: ID 056e:4010 Elecom Co., Ltd LD-USB20
```

Thank you.

Reference: https://qiita.com/aq3948/items/144feeecbd390c883b7c