### PR TITLE
Use eth_hw_addr_set instead of dev_addr_set

### DIFF
--- a/include/drv_types_linux.h
+++ b/include/drv_types_linux.h
@@ -16,7 +16,11 @@
 #define __DRV_TYPES_LINUX_H__
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0))
-#define dev_addr_set(netdev, ethdata) _rtw_memcpy(netdev->dev_addr, ethdata, ETH_ALEN) 
+/* Porting from linux kernel v5.15 48eab831ae8b9f7002a533fa4235eed63ea1f1a3 3f6cffb8604b537e3d7ea040d7f4368689638eaf*/
+static inline void eth_hw_addr_set(struct net_device *dev, const u8 *addr)
+{
+    memcpy(dev->dev_addr, addr, ETH_ALEN)
+}
 #endif
 
 #endif

--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -9725,7 +9725,7 @@ static int rtw_mp_efuse_set(struct net_device *dev,
 		rtw_hal_read_chip_info(padapter);
 		/* set mac addr*/
 		rtw_macaddr_cfg(adapter_mac_addr(padapter), get_hal_mac_addr(padapter));
-		dev_addr_set(padapter->pnetdev, get_hal_mac_addr(padapter)); /* set mac addr to net_device */
+		eth_hw_addr_set(padapter->pnetdev, get_hal_mac_addr(padapter)); /* set mac addr to net_device */
 
 #ifdef CONFIG_P2P
 		rtw_init_wifidirect_addrs(padapter, adapter_mac_addr(padapter), adapter_mac_addr(padapter));

--- a/os_dep/linux/mlme_linux.c
+++ b/os_dep/linux/mlme_linux.c
@@ -404,7 +404,7 @@ int hostapd_mode_init(_adapter *padapter)
 	mac[4] = 0x11;
 	mac[5] = 0x12;
 
-	dev_addr_set(pnetdev, mac);
+	eth_hw_addr_set(pnetdev, mac);
 
 
 	rtw_netif_carrier_off(pnetdev);

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1285,7 +1285,7 @@ static int rtw_net_set_mac_address(struct net_device *pnetdev, void *addr)
 	}
 
 	_rtw_memcpy(adapter_mac_addr(padapter), sa->sa_data, ETH_ALEN); /* set mac addr to adapter */
-	dev_addr_set(pnetdev, sa->sa_data); /* set mac addr to net_device */
+	eth_hw_addr_set(pnetdev, sa->sa_data); /* set mac addr to net_device */
 
 #if 0
 	if (rtw_is_hw_init_completed(padapter)) {
@@ -1754,7 +1754,7 @@ int rtw_os_ndev_register(_adapter *adapter, const char *name)
 	/* alloc netdev name */
 	rtw_init_netdev_name(ndev, name);
 
-	dev_addr_set(ndev, adapter_mac_addr(adapter));
+	eth_hw_addr_set(ndev, adapter_mac_addr(adapter));
 #if defined(CONFIG_NET_NS)
     dev_net_set(ndev, wiphy_net(adapter_to_wiphy(adapter)));
 #endif //defined(CONFIG_NET_NS)

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -2299,7 +2299,7 @@ int rtw_change_ifname(_adapter *padapter, const char *ifname)
 
 	rtw_init_netdev_name(pnetdev, ifname);
 
-	dev_addr_set(pnetdev, adapter_mac_addr(padapter));
+	eth_hw_addr_set(pnetdev, adapter_mac_addr(padapter));
 
 	if (rtnl_lock_needed)
 		ret = register_netdev(pnetdev);


### PR DESCRIPTION
Instead of define a dev_addr_set alias, eth_hw_addr_set should be declared for kernels < 5.15

eth_hw_addr_set was introduced on v5.15-rc1
https://github.com/torvalds/linux/commit/48eab831ae8b9f7002a533fa4235eed63ea1f1a3
For old kernels memcpy() is used, so we do the same is this patch.

It's aligned with the solution used by similar drivers on Linux kernel.
memcopy to ether_addr_copy to eth_hw_addr_set 

See for example
https://github.com/torvalds/linux/commit/b57ceb19aba7d40403ca985ec565db8db20f4331
https://github.com/torvalds/linux/commit/349f631da4e1bdcb1b4a2a3ee630d689bfe6724d

Kernels <  v5.15 will works in the same way with or without this patch, but maybe solve some issues with newer kernels, where eth_hw_addr_set has been improved.
ping @fariouche to test #1088 @Anoncheg1 for #1075 and @Reflexe to test on ArchLinux #961

Fix #1088
