### PR TITLE
Fix compilation error on kernels < 5.15

### DIFF
--- a/include/drv_types_linux.h
+++ b/include/drv_types_linux.h
@@ -19,7 +19,7 @@
 /* Porting from linux kernel v5.15 48eab831ae8b9f7002a533fa4235eed63ea1f1a3 3f6cffb8604b537e3d7ea040d7f4368689638eaf*/
 static inline void eth_hw_addr_set(struct net_device *dev, const u8 *addr)
 {
-    memcpy(dev->dev_addr, addr, ETH_ALEN)
+    memcpy(dev->dev_addr, addr, ETH_ALEN);
 }
 #endif
 


### PR DESCRIPTION
Fix missing semicolon.

I need to fix CI in order to build old kernels missing at https://kernel.ubuntu.com/~kernel-ppa/mainline/

Fix #1090