### PR TITLE
ioctl_cfg80211: fix build against kernels < 4.10.x

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -1193,12 +1193,22 @@ check_bss:
                         struct cfg80211_bss *bss;
                         bss = cfg80211_get_bss(pwdev->wiphy, NULL, cur_network->network.MacAddress, NULL, 0,
                                 IEEE80211_BSS_TYPE_ANY, IEEE80211_PRIVACY_ANY);
+		#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0)
                         cfg80211_connect_bss(wdev_to_ndev(pwdev), cur_network->network.MacAddress, bss
                                 , pmlmepriv->assoc_req + sizeof(struct rtw_ieee80211_hdr_3addr) + 2
                                 , pmlmepriv->assoc_req_len - sizeof(struct rtw_ieee80211_hdr_3addr) - 2
                                 , pmlmepriv->assoc_rsp + sizeof(struct rtw_ieee80211_hdr_3addr) + 6
                                 , pmlmepriv->assoc_rsp_len - sizeof(struct rtw_ieee80211_hdr_3addr) - 6
                                 , WLAN_STATUS_SUCCESS, GFP_ATOMIC, NL80211_TIMEOUT_UNSPECIFIED);
+		#else // (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0))
+                        // Linux < 4.10.x does not accept the last argument (timeout).
+                        cfg80211_connect_bss(wdev_to_ndev(pwdev), cur_network->network.MacAddress, bss
+                                , pmlmepriv->assoc_req + sizeof(struct rtw_ieee80211_hdr_3addr) + 2
+                                , pmlmepriv->assoc_req_len - sizeof(struct rtw_ieee80211_hdr_3addr) - 2
+                                , pmlmepriv->assoc_rsp + sizeof(struct rtw_ieee80211_hdr_3addr) + 6
+                                , pmlmepriv->assoc_rsp_len - sizeof(struct rtw_ieee80211_hdr_3addr) - 6
+                                , WLAN_STATUS_SUCCESS, GFP_ATOMIC);
+		#endif
                 }
 		#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 11, 0) || defined(COMPAT_KERNEL_RELEASE)
 		RTW_INFO("pwdev->sme_state(a)=%d\n", pwdev->sme_state);


### PR DESCRIPTION
Kernel 4.10.x adjusted cfg80211_connect_bss to accept a timeout as the last argument. Add a conditional statement which removes this extra parameter if the kernel is less than version 4.10.x to fix build errors against version 4.9.x.

Note that the Jetson TX2 kernel is still version 4.9.x even though this version is technically deprecated upstream.