### PR TITLE
Fix build on kernel 6.x.

### DIFF
--- a/os_dep/linux/wifi_regd.c
+++ b/os_dep/linux/wifi_regd.c
@@ -396,7 +396,7 @@ static void _rtw_regd_init_wiphy(struct rtw_regulatory *reg, struct wiphy *wiphy
 	wiphy->regulatory_flags &= ~REGULATORY_DISABLE_BEACON_HINTS;
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 39))
 	wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF;
 #endif
 


### PR DESCRIPTION
This was broken due to kernel changes backported from 6.5.
I found the fix for this here, so credit goes to them: https://github.com/morrownr/8812au-20210629/commit/b5f4e6e894eca8fea38661e2fc22a2570e0274ad
Breaking commit is: https://github.com/torvalds/linux/commit/e8c2af660ba0790afd14d5cbc2fd05c6dc85e207

I tested this change by building the module on Debian kernel 6.1.52-1 and 6.1.38-4.