### PR TITLE
Fixed build on 6.x kernels.

### DIFF
--- a/os_dep/linux/wifi_regd.c
+++ b/os_dep/linux/wifi_regd.c
@@ -396,7 +396,7 @@ static void _rtw_regd_init_wiphy(struct rtw_regulatory *reg, struct wiphy *wiphy
 	wiphy->regulatory_flags &= ~REGULATORY_DISABLE_BEACON_HINTS;
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 39))
 	wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF;
 #endif
 

--- a/os_dep/linux/wifi_regd.c
+++ b/os_dep/linux/wifi_regd.c
@@ -396,7 +396,15 @@ static void _rtw_regd_init_wiphy(struct rtw_regulatory *reg, struct wiphy *wiphy
 	wiphy->regulatory_flags &= ~REGULATORY_DISABLE_BEACON_HINTS;
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 39))
+/*
+ * Ubuntu backported a specific upstream change to kernel 6.2 while others skipped 6.2 altogether.
+ * If build fails on kernel 6.2.x and you're not using Ubuntu,
+ * try changing the version "(6, 3, 0)" below to "(6, 2, 0)".
+ */
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 39)) \
+	|| (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 13)) \
+	|| (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 4))
 	wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF;
 #endif
 


### PR DESCRIPTION
It was broken due to kernel changes backported from 6.5 (torvalds/linux@e8c2af6). Changes have been tested on the following configurations and observed to build:
 - Debian Bullseye, kernel 6.1.38-4 (bullseye-backports)
 - Debian Bookworm, kernel 6.1.52-1
 - Ubuntu 23.04 Lunar, kernel 6.2.0-36

EDIT:
In case someone tries to build this module running kernel 6.2 on something other than Ubuntu, they'll most likely have to change a line (described in the code).