### PR TITLE
ioctl_cfg80211: Add support for standard RSSI notifications

### DIFF
--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -1971,6 +1971,12 @@ unsigned int OnBeacon(_adapter *padapter, union recv_frame *precv_frame)
 #if 0 /* move to validate_recv_mgnt_frame */
 				psta->sta_stats.rx_mgnt_pkts++;
 #endif
+
+#if defined(CONFIG_IOCTL_CFG80211)
+				rtw_cfg80211_cqm_rssi_update(
+					padapter,
+					pmlmepriv->cur_network_scanned->network.Rssi);
+#endif
 			}
 
 		} else if ((pmlmeinfo->state & 0x03) == WIFI_FW_ADHOC_STATE) {

--- a/os_dep/linux/ioctl_cfg80211.h
+++ b/os_dep/linux/ioctl_cfg80211.h
@@ -185,6 +185,11 @@ struct rtw_wdev_priv {
 	u16 pno_scan_seq_num;
 #endif
 
+	/* Standard RSSI notification parameters */
+	s32 cqm_rssi_thold;
+	u32 cqm_rssi_hyst;
+	s32 cqm_rssi_last;
+
 #ifdef CONFIG_RTW_CFGVEDNOR_RSSIMONITOR
         s8 rssi_monitor_max;
         s8 rssi_monitor_min;
@@ -350,6 +355,8 @@ void rtw_cfg80211_rx_rrm_action(_adapter *adapter, union recv_frame *rframe);
 void rtw_cfg80211_init_rfkill(struct wiphy *wiphy);
 void rtw_cfg80211_deinit_rfkill(struct wiphy *wiphy);
 #endif
+
+void rtw_cfg80211_cqm_rssi_update(_adapter *padapter, s32 rssi);
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 4, 0))  && !defined(COMPAT_KERNEL_RELEASE)
 #define rtw_cfg80211_rx_mgmt(wdev, freq, sig_dbm, buf, len, gfp) cfg80211_rx_mgmt(wdev_to_ndev(wdev), freq, buf, len, gfp)


### PR DESCRIPTION
Currently background scanning with wpa_supplicant does not work very well because rtl8812au does not notify it about changes to RSSI.  To fix this:

* Implement the cfg80211_ops::set_cqm_rssi_config operation to set the parameters for RSSI notifications.
* Add a rtw_cfg80211_cqm_rssi_update() function that calls cfg80211_cqm_rssi_notify() if the RSSI has changed significantly (based on those parameters).
* When connected in infrastructure mode, call rtw_cfg80211_cqm_rssi_update() after processing a beacon and updating the RSSI.