### PR TITLE
Kernel compatibility fixes

### DIFF
--- a/include/drv_types_linux.h
+++ b/include/drv_types_linux.h
@@ -17,10 +17,11 @@
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0))
 /* Porting from linux kernel v5.15 48eab831ae8b9f7002a533fa4235eed63ea1f1a3 3f6cffb8604b537e3d7ea040d7f4368689638eaf*/
-static inline void eth_hw_addr_set(struct net_device *dev, const u8 *addr)
+static inline void rtw_eth_hw_addr_set(struct net_device *dev, const u8 *addr)
 {
     memcpy(dev->dev_addr, addr, ETH_ALEN);
 }
+#define eth_hw_addr_set rtw_eth_hw_addr_set
 #endif
 
 #endif

--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -1640,7 +1640,9 @@ static void __exit rtw_drv_halt(void)
 	rtw_mstat_dump(RTW_DBGDUMP);
 }
 
+#ifdef MODULE_IMPORT_NS
 MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);
+#endif
 
 module_init(rtw_drv_entry);
 module_exit(rtw_drv_halt);


### PR DESCRIPTION
Fix build failures with some of the older stable branches:

* Fix eth_hw_addr_set() definition for compatibility with stable branches
* Make use of MODULE_IMPORT_NS conditional

With these changes, I was able to build for an x86_64 defconfig build of:

* Last stable update for 4.9
* Current stable updates of 4.14, 4.19, 5.4, 5.10, 5.15, 6.1, and 6.5
* 6.6