### PR TITLE
Fix change_beacon for kernel 6.7

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -5283,9 +5283,16 @@ exit:
 	return ret;
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0))
+static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *ndev,
+		struct cfg80211_ap_update *params)
+{
+	struct cfg80211_beacon_data *info = &params->beacon; 
+#else
 static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *ndev,
 		struct cfg80211_beacon_data *info)
 {
+#endif
 	int ret = 0;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(ndev);
 


### PR DESCRIPTION
With the latest version of the kernel, the `change_beacon` function from the struct `cfg80211_ops` expects a `cfg80211_ap_update` struct as the last argument instead of `cfg80211_beacon_data`. 

[reference](https://github.com/torvalds/linux/commit/bb55441c57ccc5cc2eab44e1a97698b9d708871d/include/net/cfg80211.h) (It was changed to `cfg80211_ap_settings` then to `cfg80211_ap_update`)

Edit: this also fixes #1126 