### PR TITLE
Update Makefile to error on incompatible-pointer-types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ EXTRA_CFLAGS += -Wno-missing-declarations
 EXTRA_CFLAGS += -Wno-missing-prototypes
 #EXTRA_CFLAGS += -Wno-error=cast-function-type
 #EXTRA_CFLAGS += -Wno-parentheses-equality
-EXTRA_CFLAGS += -Wno-error=incompatible-pointer-types
+#EXTRA_CFLAGS += -Wno-error=incompatible-pointer-types
 EXTRA_CFLAGS += -Wno-stringop-overread
 #EXTRA_CFLAGS += -Wno-pointer-bool-conversion
 EXTRA_CFLAGS += -Wno-unknown-pragmas


### PR DESCRIPTION
The PR reenables a compile error if there is mismatching pointer-types. Having this set during the change between 6.6 and 6.7 allowed rtl8812au to compile - when it shouldn’t have. 
- #1126