### PR TITLE
Fix incorrect usage of access_ok() for user buffer check

### DIFF
--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -664,7 +664,7 @@ int rtw_android_priv_cmd(struct net_device *net, struct ifreq *ifr, int cmd)
 		goto exit;
 	}
 	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)) || (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8,0))
-	if (!access_ok(&priv_cmd.buf, priv_cmd.total_len)) {
+	if (!access_ok(priv_cmd.buf, priv_cmd.total_len)) {
 	#else
 	if (!access_ok(VERIFY_READ, priv_cmd.buf, priv_cmd.total_len)) {
 	#endif


### PR DESCRIPTION
The access_ok() function expects a user-space pointer as its first argument, not the address of the pointer.  This patch removes the address-of (&) operator when checking priv_cmd.buf, ensuring proper validation of the user buffer.

This fixes potential incorrect access checks that could lead to undefined behavior or security issues.