### PR TITLE
Fix Android P2P pairing issue between rtl8812au devices

### DIFF
--- a/core/rtw_ap.c
+++ b/core/rtw_ap.c
@@ -132,7 +132,9 @@ static void update_BCNTIM(_adapter *padapter)
 				offset += tmp_len + 2;
 
 			/*DS Parameter Set IE, len=3*/
-			offset += 3;
+			p = rtw_get_ie(pie + _BEACON_IE_OFFSET_, _DSSET_IE_, &tmp_len, (pnetwork_mlmeext->IELength - _BEACON_IE_OFFSET_));
+			if (p !=  NULL)
+				offset += 3;
 
 			premainder_ie = pie + offset;
 

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -1196,8 +1196,23 @@ check_bss:
 
 		if (check_fwstate(pmlmepriv, WIFI_MONITOR_STATE) != _TRUE) {
                         struct cfg80211_bss *bss;
-                        bss = cfg80211_get_bss(pwdev->wiphy, NULL, cur_network->network.MacAddress, NULL, 0,
+                        struct ieee80211_channel *chan = NULL;
+                        u32 freq = rtw_ch2freq(cur_network->network.Configuration.DSConfig);
+                        chan = ieee80211_get_channel(pwdev->wiphy, freq);
+
+                        /* Prefer exact (BSSID, SSID) match */
+                        bss = cfg80211_get_bss(pwdev->wiphy, chan,
+                                cur_network->network.MacAddress,
+                                cur_network->network.Ssid.Ssid,
+                                cur_network->network.Ssid.SsidLength,
                                 IEEE80211_BSS_TYPE_ANY, IEEE80211_PRIVACY_ANY);
+
+                        /* Fallback (rare): if not found, try wildcard as before */
+                        if (!bss) {
+                                bss = cfg80211_get_bss(pwdev->wiphy, chan,
+                                        cur_network->network.MacAddress, NULL, 0,
+                                        IEEE80211_BSS_TYPE_ANY, IEEE80211_PRIVACY_ANY);
+                        }
 		#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0) || defined(CONFIG_CFG80211_CONNECT_BSS_ANDROID))
                         cfg80211_connect_bss(wdev_to_ndev(pwdev), cur_network->network.MacAddress, bss
                                 , pmlmepriv->assoc_req + sizeof(struct rtw_ieee80211_hdr_3addr) + 2


### PR DESCRIPTION
This change resolves P2P GO/client pairing failures by:

- Ensuring the correct SSID is always used during connection through an exact (BSSID, SSID) match rather than a wildcard lookup.
- Fixing the P2P group formation fails on 5 GHz bands.