### PR TITLE
fix: kernel 6.14+ build compatibility (ccflags-y, timer API, cfg80211 signatures)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1662,6 +1662,7 @@ ifneq ($(KERNELRELEASE),)
 
 ########### this part for *.mk ############################
 include $(src)/hal/phydm/phydm.mk
+ccflags-y += $(EXTRA_CFLAGS)
 
 rtk_core :=	core/rtw_cmd.o \
 		core/rtw_security.o \

--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -54,6 +54,7 @@
 #include <linux/rtnetlink.h>
 #include <linux/delay.h>
 #include <linux/interrupt.h>	/* for struct tasklet_struct */
+#include <linux/timer.h>
 #include <linux/ip.h>
 #include <linux/kthread.h>
 #include <linux/list.h>
@@ -61,6 +62,15 @@
 
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(2, 5, 41))
 	#include <linux/tqueue.h>
+#endif
+
+/* Kernel 6.18+ removed from_timer/del_timer_sync; keep compatibility */
+#ifndef from_timer
+#define from_timer(var, callback_timer, timer_fieldname) \
+	timer_container_of(var, callback_timer, timer_fieldname)
+#endif
+#ifndef del_timer_sync
+#define del_timer_sync timer_delete_sync
 #endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 7, 0))

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -3365,7 +3365,11 @@ exit:
 	return ret;
 }
 
-static int cfg80211_rtw_set_wiphy_params(struct wiphy *wiphy, u32 changed)
+static int cfg80211_rtw_set_wiphy_params(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 0))
+	int radio_idx,
+#endif
+	u32 changed)
 {
 #if 0
 	struct iwm_priv *iwm = wiphy_to_iwm(wiphy);
@@ -4267,6 +4271,9 @@ static int cfg80211_rtw_set_txpower(struct wiphy *wiphy,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
 	struct wireless_dev *wdev,
 #endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 0))
+	int radio_idx,
+#endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 36)) || defined(COMPAT_KERNEL_RELEASE)
 	enum nl80211_tx_power_setting type, int mbm)
 #else
@@ -4327,6 +4334,9 @@ if(type == NL80211_TX_POWER_FIXED) {
 static int cfg80211_rtw_get_txpower(struct wiphy *wiphy,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
 	struct wireless_dev *wdev,
+#endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 0))
+	int radio_idx,
 #endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0))
 	unsigned int link_id,


### PR DESCRIPTION
## Summary
Fixes out-of-tree build on kernel 6.14+ by ensuring module flags are applied and updating compatibility shims.

Refs #1249

## Changes
- Makefile: map EXTRA_CFLAGS into ccflags-y in the KERNELRELEASE block
- include/osdep_service_linux.h: add from_timer/del_timer_sync compatibility shims
- os_dep/linux/ioctl_cfg80211.c: update cfg80211 op signatures for radio_idx and link_id

## Testing
- make -j$(nproc)
