### PR TITLE
Fix build for kernel 6.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ EXTRA_CFLAGS += -Wno-vla -g
 
 EXTRA_CFLAGS += -I$(src)/include -I$(srctree)/$(src)/include
 EXTRA_CFLAGS += -I$(src)/hal/phydm -I$(srctree)/$(src)/hal/phydm
-EXTRA_LDFLAGS += --strip-all -O3
+EXTRA_LDFLAGS += --strip-debug -O3
 
 ########################## WIFI IC ############################
 CONFIG_RTL8812A = y


### PR DESCRIPTION
With kernel 6.19 and CONFIG_X86_KERNEL_IBT or CONFIG_KLP_BUILD enabled, objtool runs on the linked module object (delayed objtool via --link). The module Makefile passes --strip-all to ld -r, which strips local function symbols. Without these symbols, objtool cannot determine function boundaries and reports errors like:

  88XXau.o: warning: objtool: rtw_mp_cmd+0xf8: unannotated intra-function call

Replace --strip-all with --strip-debug to preserve function symbols while still stripping debug information, allowing objtool to properly validate the linked module object.

Tested with kernel 6.19.8 on x86_64 with CONFIG_X86_KERNEL_IBT=y and CONFIG_KLP_BUILD=y.