### PR TITLE
Rtkmips 9607c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ modules.order
 *.mod
 *.o.d
 *.c.orig 
+make.log

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,16 @@
 EXTRA_CFLAGS += $(USER_EXTRA_CFLAGS) -fno-pie
 EXTRA_CFLAGS += -O3
+
+# -------------------------------------------------------------------
+# 隔离其它 Realtek in-tree 驱动（rtl8192cd / g6_wifi_driver 等）通过
+# include/generated/autoconf.h 全局泄漏进来的 HCI 相关宏，否则会和
+# 本驱动的 CONFIG_USB_HCI 同时生效，导致 rtw_xmit.h / hal_data.h 中
+# 结构体成员重复（xmit_tasklet / IntArray / IntrMask）、TXDESC_OFFSET
+# 重定义等一连串编译错误。
+# -------------------------------------------------------------------
+EXTRA_CFLAGS += -DCONFIG_USB_HCI
+EXTRA_CFLAGS += -UCONFIG_PCI_HCI -UCONFIG_SDIO_HCI -UCONFIG_GSPI_HCI
+
 EXTRA_CFLAGS += -Wno-unused-variable
 #EXTRA_CFLAGS += -Wno-unused-value
 EXTRA_CFLAGS += -Wno-unused-label
@@ -97,7 +108,8 @@ CONFIG_RTW_SDIO_PM_KEEP_POWER = y
 ###################### MP HW TX MODE FOR VHT #######################
 CONFIG_MP_VHT_HW_TX_MODE = n
 ###################### Platform Related #######################
-CONFIG_PLATFORM_I386_PC = y
+CONFIG_PLATFORM_RTK9607C = y
+CONFIG_PLATFORM_I386_PC = n
 CONFIG_PLATFORM_ANDROID_ARM64 = n
 CONFIG_PLATFORM_ARM_RPI = n
 CONFIG_PLATFORM_ARM64_RPI = n
@@ -654,6 +666,34 @@ EXTRA_CFLAGS += -DDM_ODM_SUPPORT_TYPE=0x04
 ifeq ($(CONFIG_RTW_VIRTUAL_INTF), y)
 EXTRA_CFLAGS += -DRTW_VIRTUAL_INTF=1
 endif
+
+###############################################################################
+# Realtek RTK9607C (MIPS, big-endian, in-tree build inside SDK kernel)
+#
+# 只需要向编译器追加宏开关即可，ARCH / CROSS_COMPILE / KSRC 等由顶层
+# SDK Makefile(`make linux_only`) 传入，不要在此处再设置，否则一旦切到
+# out-of-tree 构建会被覆盖/污染（尤其不要在 := 赋值行尾混中文注释）。
+#
+#   -DCONFIG_IOCTL_CFG80211      启用 cfg80211 路径（iw / nl80211 必需）
+#   -DRTW_USE_CFG80211_STA_EVENT 通过 cfg80211 上报 STA 事件
+#   -DCONFIG_BIG_ENDIAN          MIPS EB 必需，影响 desc/寄存器字段序
+#   -DCONFIG_PLATFORM_RTK_9607C  选中 9607C 平台特殊初始化
+###############################################################################
+ifeq ($(CONFIG_PLATFORM_RTK9607C), y)
+EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+EXTRA_CFLAGS += -DCONFIG_BIG_ENDIAN -DCONFIG_PLATFORM_RTK_9607C
+
+# 以下变量仅用于 out-of-tree 构建（`make -C $(KSRC) M=...` / `make install`），
+# in-tree 构建时会被顶层 kbuild 忽略。留在这里方便独立编译调试，不影响 SDK 流程。
+ARCH           ?= mips
+CROSS_COMPILE  ?= /share/rlx/msdk-10.3.0-mips-EB-5.10-g2.30-m32s-210630/bin/msdk-linux-
+KSRC           ?= /mnt/nvme0n1p3/huangyongjin/hyjpdd1/sdk_0225/linux-5.10.x
+KVER           ?= 5.10.70
+MODDESTDIR     ?= /lib/modules/$(KVER)/kernel/drivers/net/wireless/realtek
+STAGINGMODDIR  ?= /lib/modules/$(KVER)/kernel/drivers/staging
+INSTALL_PREFIX ?=
+endif
+
 
 ifeq ($(CONFIG_PLATFORM_I386_PC), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN

--- a/include/rtl_autoconf.h
+++ b/include/rtl_autoconf.h
@@ -24,12 +24,37 @@
 #define RTL871X_MODULE_NAME "8812AU"
 
 /*
+ * 本驱动为 USB 接口（CONFIG_USB_HCI）。其它 Realtek in-tree 驱动
+ * （rtl8192cd / g6_wifi_driver 等）在 .config 中打开了 CONFIG_PCI_HCI，
+ * 会经由 include/generated/autoconf.h 全局泄漏进来，导致 rtw_xmit.h /
+ * hal_data.h 中同一结构体在 USB 分支与 PCI 分支同时展开，产生重复成员
+ * （xmit_tasklet / IntArray / IntrMask）以及 TXDESC_OFFSET 重定义。
+ * 在此处（所有 .c 最早包含的头之一）集中清理一次。
+ *
+ * 注意：不能只在 Makefile 里 -UCONFIG_PCI_HCI，因为 GCC 规则是
+ *       -include 总在所有 -D/-U 之后处理，autoconf.h 会把宏又定义回来。
+ */
+#undef CONFIG_PCI_HCI
+#undef CONFIG_SDIO_HCI
+#undef CONFIG_GSPI_HCI
+
+/*
+ * 同样来自 g6_wifi_driver / rtl8192cd 的 Kconfig 泄漏，本驱动 Makefile
+ * 已将其关闭（= n），但全局 autoconf.h 会重新定义回来，导致 rtl8812au
+ * 编译出 rtw_vendor_ie_get_api 等 EXPORT_SYMBOL 与 rtk_wifi6 重复，
+ * insmod 时报 "exports duplicate symbol"。
+ */
+#undef CONFIG_APPEND_VENDOR_IE_ENABLE
+
+/*
 #ifndef DRV_NAME
 #define DRV_NAME "rtl8812au"
 #endif
 */
 
+#ifndef CONFIG_USB_HCI
 #define CONFIG_USB_HCI
+#endif
 
 #define PLATFORM_LINUX
 

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -6356,15 +6356,34 @@ static int cfg80211_rtw_set_monitor_channel(struct wiphy *wiphy
 		break;
 	case NL80211_CHAN_WIDTH_80:
 		target_width = CHANNEL_WIDTH_80;
-		target_offset = HAL_PRIME_CHNL_OFFSET_DONT_CARE;
+		/*
+		 * 对于 80/160MHz，set_channel_bwmode() 在内部会用
+		 * rtw_get_scch_by_cch_offset(cch_40, CHANNEL_WIDTH_40, target_offset)
+		 * 去推导 primary 20MHz 的中心，因此此处 target_offset 必须是
+		 * primary-20-in-40 的方位（LOWER/UPPER），而不是 DONT_CARE。
+		 * 否则会在 rtw_rf.c:225 触发 WARN。
+		 */
+		{
+			u8 off = HAL_PRIME_CHNL_OFFSET_DONT_CARE;
+			rtw_get_offset_by_chbw(chan->hw_value, CHANNEL_WIDTH_40, &off);
+			target_offset = off;
+		}
 		break;
 	case NL80211_CHAN_WIDTH_80P80:
 		target_width = CHANNEL_WIDTH_80_80;
-		target_offset = HAL_PRIME_CHNL_OFFSET_DONT_CARE;
+		{
+			u8 off = HAL_PRIME_CHNL_OFFSET_DONT_CARE;
+			rtw_get_offset_by_chbw(chan->hw_value, CHANNEL_WIDTH_40, &off);
+			target_offset = off;
+		}
 		break;
 	case NL80211_CHAN_WIDTH_160:
 		target_width = CHANNEL_WIDTH_160;
-		target_offset = HAL_PRIME_CHNL_OFFSET_DONT_CARE;
+		{
+			u8 off = HAL_PRIME_CHNL_OFFSET_DONT_CARE;
+			rtw_get_offset_by_chbw(chan->hw_value, CHANNEL_WIDTH_40, &off);
+			target_offset = off;
+		}
 		break;
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 11, 0))


### PR DESCRIPTION
RTK9607C MIPS BE + Linux 5.10.70 SDK）使用这个rtl8812au网卡
屏蔽了自带的.config 一些宏对这个驱动目录的污染
修改 iw dev wlan2 set 36 80MHz 出现的错误问题。
