### PR TITLE
core: rtw_sta_mgt: clear defrag queue in rtw_free_stainfo (CVE-2020-24586)

### DIFF
--- a/core/rtw_sta_mgt.c
+++ b/core/rtw_sta_mgt.c
@@ -749,6 +749,18 @@ u32	rtw_free_stainfo(_adapter *padapter , struct sta_info *psta)
 
 	}
 
+	/* Drain any fragments left in this STA's defragmentation queue.
+	 * Reassembly may have been incomplete (peer left mid-sequence, or
+	 * the AP roamed away with a 0..n-1 fragment buffered). Without this
+	 * drain the recv_frame slots stay attached to the freed sta_info
+	 * and leak from the adapter's free_recv_queue pool, eventually
+	 * exhausting it after enough disconnect cycles. The neighbouring
+	 * reordering_ctrl pending queues are already drained above; defrag_q
+	 * was the missing peer.
+	 */
+	rtw_free_recvframe_queue(&psta->sta_recvpriv.defrag_q,
+				 &padapter->recvpriv.free_recv_queue);
+
 	if (!((psta->state & WIFI_AP_STATE) || MacAddr_isBcst(psta->cmn.mac_addr)) && is_pre_link_sta == _FALSE)
 		rtw_hal_set_odm_var(padapter, HAL_ODM_STA_INFO, psta, _FALSE);
 


### PR DESCRIPTION
## Summary

Addresses **CVE-2020-24586** ("Not clearing fragments from memory when (re)connecting to a network") — part of the **FragAttacks** family disclosed by Mathy Vanhoef in May 2021.

aircrack-ng/rtl8812au appears to be the only popular RTL8812/8821AU fork that still ships unpatched. Both `morrownr/8821au-20210708` and `morrownr/8812au-20210820` already merged the same drain (with explicit `/* CVE-2020-24586, clear defrag queue */` comment) — this PR ports that fix here.

## Reference

- CVE: https://nvd.nist.gov/vuln/detail/CVE-2020-24586
- FragAttacks paper: https://www.fragattacks.com/
- morrownr/8821au-20210708 fix: see `core/rtw_sta_mgt.c` line 803-814 in that repo

## Root cause

`rtw_free_stainfo()` already drains the per-TID A-MPDU reordering pending queues (the for-loop over 16 TIDs). Right below that block, the function moves on to MAC-id release and association cleanup — and silently leaves `psta->sta_recvpriv.defrag_q` untouched.

If the peer disconnects mid-fragmented-sequence (roam, disassoc, signal loss with a 0..n-1 fragment buffered), `recv_frame` slots holding partial plaintext fragments stay attached to the freed `sta_info`. On the same station's next association those buffered fragments can be reassembled with new ones encrypted under a different key — exactly the CVE-2020-24586 scenario. Separately the recv_frames also leak from the adapter's `free_recv_queue` pool, eventually exhausting it after enough disconnect cycles.

`_rtw_free_sta_recv_priv_lock()` (called from `rtw_mfree_stainfo()`) only frees the queue's spinlock, not its contents, so there is no other point in the teardown path that drains this queue.

## Fix

Walk the defrag_q list under its spinlock and free each `recv_frame` back to the adapter's free_recv_queue, mirroring exactly the pattern used in the morrownr forks for the same CVE. The drain is placed immediately after the existing reorder-queue drain in `rtw_free_stainfo()`.

## Test environment

- Realtek 8821AU (USB ID `0bda:0811`) on Raspberry Pi 2B, kernel 6.12.47
- Static analysis only; the leak is slow enough that runtime observation requires many disconnect cycles
- Cross-checked the patch shape against the merged morrownr fix to ensure consistency

## Disclosure

This patch is the result of a code-review pass conducted with the help of an LLM (Claude). The reasoning was verified against the existing reorder-queue drain pattern in the same function, the matching `rtw_free_recvframe_queue` call in `recvframe_chk_defrag`, and the already-merged CVE-2020-24586 fixes in the morrownr sister forks. I am not a kernel engineer.
