### PR TITLE
fix: use unsigned long for tasklet callbacks to satisfy CFI

### DIFF
--- a/core/mesh/rtw_mesh.c
+++ b/core/mesh/rtw_mesh.c
@@ -2670,7 +2670,7 @@ exit:
 	return annc_cnt;
 }
 
-static void mpath_tx_tasklet_hdl(void *priv)
+static void mpath_tx_tasklet_hdl(unsigned long priv)
 {
 	_adapter *adapter = (_adapter *)priv;
 	struct rtw_mesh_info *minfo = &adapter->mesh_info;

--- a/hal/rtl8812a/usb/usb_ops_linux.c
+++ b/hal/rtl8812a/usb/usb_ops_linux.c
@@ -207,7 +207,7 @@ _exit_recvbuf2recvframe:
 }
 
 
-void rtl8812au_xmit_tasklet(void *priv)
+void rtl8812au_xmit_tasklet(unsigned long priv)
 {
 	int ret = _FALSE;
 	_adapter *padapter = (_adapter *)priv;

--- a/hal/rtl8814a/usb/usb_ops_linux.c
+++ b/hal/rtl8814a/usb/usb_ops_linux.c
@@ -247,7 +247,7 @@ _exit_recvbuf2recvframe:
 }
 #endif
 
-void rtl8814au_xmit_tasklet(void *priv)
+void rtl8814au_xmit_tasklet(unsigned long priv)
 {
 	int ret = _FALSE;
 	_adapter *padapter = (_adapter*)priv;

--- a/include/rtl8812a_xmit.h
+++ b/include/rtl8812a_xmit.h
@@ -330,7 +330,7 @@ s32 rtl8812au_hal_xmit(PADAPTER padapter, struct xmit_frame *pxmitframe);
 s32 rtl8812au_mgnt_xmit(PADAPTER padapter, struct xmit_frame *pmgntframe);
 s32	 rtl8812au_hal_xmitframe_enqueue(_adapter *padapter, struct xmit_frame *pxmitframe);
 s32 rtl8812au_xmit_buf_handler(PADAPTER padapter);
-void rtl8812au_xmit_tasklet(void *priv);
+void rtl8812au_xmit_tasklet(unsigned long priv);
 s32 rtl8812au_xmitframe_complete(_adapter *padapter, struct xmit_priv *pxmitpriv, struct xmit_buf *pxmitbuf);
 #endif
 

--- a/include/rtl8814a_xmit.h
+++ b/include/rtl8814a_xmit.h
@@ -276,7 +276,7 @@ void fill_txdesc_bmc_tx_rate(struct pkt_attrib *pattrib, u8 *ptxdesc);
 	s32 rtl8814au_mgnt_xmit(PADAPTER padapter, struct xmit_frame *pmgntframe);
 	s32	 rtl8814au_hal_xmitframe_enqueue(_adapter *padapter, struct xmit_frame *pxmitframe);
 	s32 rtl8814au_xmit_buf_handler(PADAPTER padapter);
-	void rtl8814au_xmit_tasklet(void *priv);
+	void rtl8814au_xmit_tasklet(unsigned long priv);
 	s32 rtl8814au_xmitframe_complete(_adapter *padapter, struct xmit_priv *pxmitpriv, struct xmit_buf *pxmitbuf);
 #endif /* CONFIG_USB_HCI */
 


### PR DESCRIPTION
Kernel builds with CONFIG_CFI_CLANG (e.g. LTO+CFI Android kernels) type-check indirect calls at runtime: tasklet callbacks are invoked by the core as `void (*)(unsigned long)`, but `rtl8812au_xmit_tasklet`, `rtl8814au_xmit_tasklet` and `mpath_tx_tasklet_hdl` were declared with a `void *` parameter.

The type mismatch trips `__cfi_check` and causes a kernel panic (seen as `__cfi_check_fail` in the call trace, e.g. `tasklet_hi_action -> tasklet_action_common -> __cfi_slowpath`) whenever the xmit tasklet is scheduled via `tasklet_hi_schedule` (e.g. packet injection with `aireplay-ng --test`).

Same fix pattern as the earlier `usb_recv_tasklet` CFI fix (PR #1041): change the parameter type to `unsigned long`, keep the body cast unchanged.

Tested on Xiaomi 11 Lite 5G NE (lisa), MeowKernel 5.4.302 with CONFIG_CFI_CLANG: `aireplay-ng --test` now passes 30/30 (100%) injection without panic.