### PR TITLE
wifi: rtl8812au: restore data frame reception in monitor mode (RCR_ACRC32/AICV, RXFLTMAP0/1)

### DIFF
--- a/hal/rtl8812a/rtl8812a_hal_init.c
+++ b/hal/rtl8812a/rtl8812a_hal_init.c
@@ -4167,6 +4167,7 @@ static void hw_var_set_monitor(PADAPTER Adapter, u8 variable, u8 *val)
 
 		/* Append FCS */
 		rcr_bits |= RCR_APPFCS;
+		rcr_bits |= RCR_ACRC32 | RCR_AICV; // accept CRC/ICV-error frames (chip-level gate)
 #endif
 #if 0
 		/*
@@ -4181,6 +4182,8 @@ static void hw_var_set_monitor(PADAPTER Adapter, u8 variable, u8 *val)
 
 		/* Receive all data frames */
 		value_rxfltmap2 = 0xFFFF;
+		rtw_write16(Adapter, REG_RXFLTMAP0, value_rxfltmap2);
+		rtw_write16(Adapter, REG_RXFLTMAP1, value_rxfltmap2);
 		rtw_write16(Adapter, REG_RXFLTMAP2, value_rxfltmap2);
 
 #if 0

--- a/hal/rtl8812a/usb/usb_ops_linux.c
+++ b/hal/rtl8812a/usb/usb_ops_linux.c
@@ -145,7 +145,7 @@ int recvbuf2recvframe(PADAPTER padapter, void *ptr)
 
 		pattrib = &precvframe->u.hdr.attrib;
 
-		if ((padapter->registrypriv.mp_mode == 0) && ((pattrib->crc_err) || (pattrib->icv_err))) {
+		if ((padapter->registrypriv.mp_mode == 0) && !check_fwstate(&padapter->mlmepriv, WIFI_MONITOR_STATE) && ((pattrib->crc_err) || (pattrib->icv_err))) {
 			RTW_INFO("%s: RX Warning! crc_err=%d icv_err=%d, skip!\n", __FUNCTION__, pattrib->crc_err, pattrib->icv_err);
 
 			rtw_free_recvframe(precvframe, pfree_recv_queue);

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -6311,7 +6311,7 @@ static int cfg80211_rtw_get_channel(struct wiphy *wiphy, struct wireless_dev *wd
 }
 
 static int cfg80211_rtw_set_monitor_channel(struct wiphy *wiphy
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0))
 	, struct net_device *dev
 	, struct cfg80211_chan_def *chandef
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))


### PR DESCRIPTION
## Summary

Restore **data frame reception in monitor mode** on recent kernels. With the current master, an RTL8812AU in monitor mode captures management and control frames (beacons, probes, auth, assoc, ACK, RTS/CTS, BlockAck) but **zero data frames** — including the EAPOL 4-way handshake required for WPA2 cracking. The chip discards data frames in hardware before the driver ever sees them.

## Problem

- `iw dev wlan0 set type monitor` works, radiotap frames flow.
- `airodump-ng` / `tcpdump` / `hcxdumptool` see beacons, probes, auth, assoc, control frames — **no data frames, no EAPOL**.
- `hcxpcapngtool`: `This dump file does not contain enough EAPOL M1 frames`.
- `rtw_usb_rxagg_mode=0` only unblocks low-rate non-aggregated data; high-rate unicast and handshake frames stay invisible.
- `rtw_mp_mode=1` "works" — because the MP path sets `ReceiveConfig |= RCR_ACRC32` (`core/rtw_mp.c`).

## Root cause

A frame-type probe in `recv_func()` showed `fw_state=0x80000000` (monitor state **is** set) and only `type=0` (mgmt) / `type=4` (ctrl) frames arriving — **`type=8` (data) never reaches the driver**, and `recvbuf2recvframe()` drop messages never fire. The filter is the chip's RCR:

`hw_var_set_monitor()` has `RCR_ACRC32 | RCR_AICV` disabled inside `#if 0` with the comment *"CRC and ICV packet will drop in recvbuf2recvframe() We no turn on it"*. That assumption is wrong: without `RCR_ACRC32|RCR_AICV` the **chip drops CRC/ICV-flagged frames in hardware** — and in monitor mode the chip flags foreign encrypted frames (no keys installed) with exactly those errors. The frames are gone before any driver code can see them.

Secondary issue: upstream writes only `REG_RXFLTMAP2 = 0xFFFF` (management/control filter); `REG_RXFLTMAP0/1` (data-subtype filters) stay at STA-mode defaults. The 5.13.6-based releases wrote all three.

## Changes

| Commit | Change |
|---|---|
| `192aca3` | Enable `RCR_ACRC32 \| RCR_AICV` in the monitor RCR; write `REG_RXFLTMAP0/1 = 0xFFFF` (accept all data subtypes) |
| `e8fc70e` | Don't drop CRC/ICV-flagged frames in `recvbuf2recvframe()` when `WIFI_MONITOR_STATE` is set (radiotap carries the flags for userspace) |
| `64c416f` | Build fix: `set_monitor_channel` `net_device` param guard `>= 6.13` → `>= 6.12` (the param is present in 6.12 headers) |

## Testing

Environment: Manjaro, kernel `6.12.103-1-MANJARO`, RTL8812AU (USB `0bda:8812`), aircrack-ng master @ `7344855`. 35 s monitor capture on ch6 with three client reconnects:

| Metric | Before | After |
|---|---|---|
| Data frames captured | 0–27 (low-rate only) | **1028** |
| High-rate data (24–52 Mbit/s) | 0 | **54** |
| Data frames reaching `recv_func()` | 0 | 109 (debug build, `type=8`) |

WPA2 handshake capture pipeline (deauth → reconnect → EAPOL → `hcxpcapngtool`) verified working after the fix.

## Notes

- This restores the driver's ability to receive data frames. Networks using **WPA3/SAE + PMF** still cannot be cracked from a passive capture — with PMF the handshake itself is protected; that is a security feature, not a driver issue.
- The optional `-DDBG_RX_DROP_FRAME` build flag used during debugging, plus a longer writeup, live in the companion repo: https://github.com/Nombah501/rtl8812au-monitor-rx-fix
- Same `hw_var_set_monitor` pattern exists for other chips in this driver family; they likely need the identical fix.
